### PR TITLE
ci: debug solx-tester on macOS runners (main baseline for #524 mac validation)

### DIFF
--- a/.github/workflows/mac-tester-debug.yaml
+++ b/.github/workflows/mac-tester-debug.yaml
@@ -1,0 +1,166 @@
+name: Mac solx-tester debug
+
+# Temporary debugging workflow: get solx-tester running on macOS runners.
+# Context: solx-tester has no macOS CI coverage anywhere; PR #545 showed it
+# being signal-killed on macos-15-large and hanging on macos-15-xlarge, but
+# with PR #524 included, so mac breakage and #524 regressions were
+# indistinguishable. This branch is plain `main`, so its results are the
+# macOS baseline.
+#
+# The build-llvm/build-solc parameters deliberately mirror test.yaml's macOS
+# legs so both hit the finished-install caches saved on main (v1-llvm-macOS-*,
+# v1-solc-macOS-*): nothing is compiled but the Rust workspace.
+
+on:
+  push:
+    branches:
+      - mac-tester-debug
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tester:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-15, macos-15-large, macos-15-xlarge]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    env:
+      RUST_BACKTRACE: full
+      # Keep symbols in the release binaries (Cargo.toml sets strip = true)
+      # so crash reports and `sample` output are readable.
+      CARGO_PROFILE_RELEASE_STRIP: none
+      CARGO_PROFILE_RELEASE_DEBUG: line-tables-only
+      BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
+      SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: true
+
+      - name: Checkout submodules
+        uses: ./.github/actions/checkout-submodules
+
+      - name: Runner environment
+        run: |
+          sysctl hw.memsize hw.ncpu machdep.cpu.brand_string || true
+          df -h .
+          ulimit -a
+
+      - name: Free disk space (macOS)
+        uses: ./.github/actions/free-disk-space-macos
+
+      - name: Setup SFW
+        uses: ./.github/actions/setup-sfw
+
+      - name: Build LLVM
+        uses: ./.github/actions/build-llvm
+        with:
+          build-type: RelWithDebInfo
+          enable-assertions: 'true'
+          enable-mlir: 'true'
+          enable-utils: 'true'
+
+      - name: Build solc
+        uses: ./.github/actions/build-solc
+        with:
+          cmake-build-type: RelWithDebInfo
+          working-dir: 'solx-solidity'
+
+      - name: Build solx and solx-tester
+        run: |
+          ${SFW_PREFIX:-} cargo fetch --locked
+          ${SFW_PREFIX:-} cargo build --frozen --release --bin solx --bin solx-tester
+
+      # Timestamp marker: the crash-report collector only prints reports newer
+      # than this, excluding crashes from earlier steps (e.g. the LLVM build).
+      - name: Mark crash-report baseline
+        run: touch "${RUNNER_TEMP}/ips-baseline"
+
+      # solx-tester is invoked directly (not via `solx-dev test solx-tester`):
+      # the wrapper reduces a signal death to "subprocess failed without exit
+      # code", while here the exit code names the signal.
+      - name: Smoke test (one test, one thread)
+        id: smoke
+        continue-on-error: true
+        timeout-minutes: 15
+        run: |
+          set +e
+          ./target/release/solx-tester \
+            --solidity-compiler ./target/release/solx \
+            --path tests/solidity/simple/default.sol \
+            --threads 1 \
+            --verbose
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
+
+      # The watchdog exists for the macos-15-xlarge failure mode: a run that
+      # neither crashes nor finishes. `sample` captures where the tester and
+      # its solx workers are stuck before the kill.
+      - name: Full run (default threads, 30-minute watchdog)
+        id: full
+        continue-on-error: true
+        timeout-minutes: 45
+        run: |
+          set +e
+          ./target/release/solx-tester --solidity-compiler ./target/release/solx &
+          PID=$!
+          elapsed=0
+          while kill -0 "$PID" 2>/dev/null; do
+            if [ "$elapsed" -ge 1800 ]; then
+              echo "::error::solx-tester still running after ${elapsed}s; sampling, then killing"
+              pgrep -fl 'solx' || true
+              sample "$PID" 10 -file solx-tester-hang.sample.txt || true
+              for p in $(pgrep -f -- '--recursive-process' | head -5); do
+                sample "$p" 5 -file "solx-worker-${p}.sample.txt" || true
+              done
+              kill -9 "$PID"
+              wait "$PID"
+              exit 124
+            fi
+            sleep 30
+            elapsed=$((elapsed + 30))
+          done
+          wait "$PID"
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
+
+      - name: Collect crash reports and samples
+        if: always()
+        run: |
+          mkdir -p diagnostics
+          cp ./*.sample.txt diagnostics/ 2>/dev/null || true
+          find "${HOME}/Library/Logs/DiagnosticReports" -type f -newer "${RUNNER_TEMP}/ips-baseline" 2>/dev/null \
+            | while read -r report; do
+                echo "=== ${report} ==="
+                head -c 20000 "${report}"
+                echo
+                cp "${report}" diagnostics/ || true
+              done
+          ls -la diagnostics/ || true
+
+      - name: Upload diagnostics
+        if: always() && hashFiles('diagnostics/*') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mac-tester-diagnostics-${{ matrix.runner }}
+          path: diagnostics/
+
+      - name: Fail if any stage failed
+        if: steps.smoke.outcome != 'success' || steps.full.outcome != 'success'
+        run: |
+          echo "smoke: ${{ steps.smoke.outcome }}, full: ${{ steps.full.outcome }}"
+          exit 1

--- a/.github/workflows/mac-tester-debug.yaml
+++ b/.github/workflows/mac-tester-debug.yaml
@@ -141,35 +141,49 @@ jobs:
           fi
           exit "$ec"
 
-      # lldb autopsy of the Intel-only SIGSEGV (deterministic, single-thread,
-      # not heap corruption per run 29366844647: identical 0x12-pattern
-      # registers even under MallocScribble; ASAN silent). Line tables are
-      # kept in the build, so `bt` resolves the inlined frames at the crash
-      # site to file:line, and the last --verbose line names the test.
-      - name: 'Diagnose: lldb crash autopsy (Intel)'
+      # Toolchain probes for the Intel SIGSEGV. The lldb autopsy (run
+      # 29371120991) showed an aligned SSE store to a structurally misaligned
+      # frame slot in Input::try_from_ethereum — a codegen bug matching the
+      # rust-lang/rust#159035 family (enum-niche miscompile, present in
+      # 1.96.1, LLVM fix backport pending as 1.97.1). If 1.95.0 is green and
+      # nightly (fixed LLVM) is green while the pinned 1.96.1 crashes, the fix
+      # is a toolchain bump, not a code change.
+      - name: 'Probe: rustc 1.95.0 (Intel)'
         if: matrix.runner == 'macos-15-large'
         continue-on-error: true
-        timeout-minutes: 25
+        timeout-minutes: 30
         run: |
-          lldb --batch \
-            -o run \
-            -k 'thread backtrace -c 25' \
-            -k 'disassemble --pc --count 12' \
-            -k 'register read rax rbx rcx rdx rsi rdi r8 r9 rip rsp' \
-            -k 'quit' \
-            -- ./target/release/solx-tester \
-              --solidity-compiler ./target/release/solx \
-              --path semanticTests \
-              --threads 1 \
-              --verbose
+          set +e
+          rustup toolchain install 1.95.0 --profile minimal || exit 1
+          ${SFW_PREFIX:-} cargo +1.95.0 build --frozen --release \
+            -p solx-tester --bin solx-tester --target-dir target-195 || exit 1
+          ./target-195/release/solx-tester \
+            --solidity-compiler ./target/release/solx \
+            --path semanticTests
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::1.95.0 tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
 
-      # Offline-symbolication backup for the recorded .ips offsets.
-      - name: Upload solx-tester binary
-        if: always() && matrix.runner == 'macos-15-large'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: solx-tester-binary-${{ matrix.runner }}
-          path: target/release/solx-tester
+      - name: 'Probe: rustc nightly (Intel)'
+        if: matrix.runner == 'macos-15-large'
+        continue-on-error: true
+        timeout-minutes: 30
+        run: |
+          set +e
+          rustup toolchain install nightly --profile minimal || exit 1
+          rustup run nightly rustc --version --verbose
+          ${SFW_PREFIX:-} cargo +nightly build --frozen --release \
+            -p solx-tester --bin solx-tester --target-dir target-nightly || exit 1
+          ./target-nightly/release/solx-tester \
+            --solidity-compiler ./target/release/solx \
+            --path semanticTests
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::nightly tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
 
       - name: Collect crash reports and samples
         if: always()

--- a/.github/workflows/mac-tester-debug.yaml
+++ b/.github/workflows/mac-tester-debug.yaml
@@ -28,7 +28,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-15, macos-15-large, macos-15-xlarge]
+        # macos-15-xlarge is commented out while iterating on the Intel crash:
+        # its baseline (main: full suite in 5m31s, run 29364158123) is already
+        # recorded, and it is the most expensive runner of the three.
+        runner: [macos-15, macos-15-large]  # macos-15-xlarge
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     env:
@@ -132,6 +135,75 @@ jobs:
             elapsed=$((elapsed + 30))
           done
           wait "$PID"
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
+
+      # The three steps below chase the Intel-only SIGSEGV (garbage pointer
+      # assembled from caller-address bytes, i.e. memory corruption; see run
+      # 29364158123). `--path semanticTests` narrows to the Ethereum corpus
+      # where it crashes. All are diagnostics: continue-on-error, Intel-only.
+
+      # Concurrency dependence: the crash normally fires within ~30s at
+      # default threads. Surviving a whole single-threaded corpus pass
+      # strongly suggests a data race / cross-thread lifetime bug.
+      - name: 'Diagnose: single-threaded corpus (Intel)'
+        if: matrix.runner == 'macos-15-large'
+        continue-on-error: true
+        timeout-minutes: 25
+        run: |
+          set +e
+          ./target/release/solx-tester \
+            --solidity-compiler ./target/release/solx \
+            --path semanticTests \
+            --threads 1
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
+
+      # macOS malloc debugging, no rebuild: freed memory is filled with 0x55,
+      # fresh allocations with 0xAA. If the crash pointer changes from 0x12…
+      # to one of those patterns, it is use-after-free / use-of-uninitialized
+      # respectively; guard pages may move the crash to the corrupting write.
+      - name: 'Diagnose: malloc scribble (Intel)'
+        if: matrix.runner == 'macos-15-large'
+        continue-on-error: true
+        timeout-minutes: 15
+        env:
+          MallocScribble: '1'
+          MallocPreScribble: '1'
+          MallocGuardEdges: '1'
+        run: |
+          set +e
+          ./target/release/solx-tester \
+            --solidity-compiler ./target/release/solx \
+            --path semanticTests
+          ec=$?
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+          exit "$ec"
+
+      # AddressSanitizer names the exact allocation/free/use sites. Only
+      # solx-tester is instrumented (separate target dir, nightly rustc);
+      # the solx subprocess stays the stable release build.
+      - name: 'Diagnose: ASAN corpus run (Intel)'
+        if: matrix.runner == 'macos-15-large'
+        continue-on-error: true
+        timeout-minutes: 40
+        run: |
+          set +e
+          rustup toolchain install nightly --profile minimal || exit 1
+          RUSTFLAGS="-Zsanitizer=address" ${SFW_PREFIX:-} cargo +nightly build \
+            --release -p solx-tester --bin solx-tester \
+            --target x86_64-apple-darwin --target-dir target-asan || exit 1
+          ./target-asan/x86_64-apple-darwin/release/solx-tester \
+            --solidity-compiler ./target/release/solx \
+            --path semanticTests
           ec=$?
           if [ "$ec" -gt 128 ]; then
             echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"

--- a/.github/workflows/mac-tester-debug.yaml
+++ b/.github/workflows/mac-tester-debug.yaml
@@ -141,74 +141,35 @@ jobs:
           fi
           exit "$ec"
 
-      # The three steps below chase the Intel-only SIGSEGV (garbage pointer
-      # assembled from caller-address bytes, i.e. memory corruption; see run
-      # 29364158123). `--path semanticTests` narrows to the Ethereum corpus
-      # where it crashes. All are diagnostics: continue-on-error, Intel-only.
-
-      # Concurrency dependence: the crash normally fires within ~30s at
-      # default threads. Surviving a whole single-threaded corpus pass
-      # strongly suggests a data race / cross-thread lifetime bug.
-      - name: 'Diagnose: single-threaded corpus (Intel)'
+      # lldb autopsy of the Intel-only SIGSEGV (deterministic, single-thread,
+      # not heap corruption per run 29366844647: identical 0x12-pattern
+      # registers even under MallocScribble; ASAN silent). Line tables are
+      # kept in the build, so `bt` resolves the inlined frames at the crash
+      # site to file:line, and the last --verbose line names the test.
+      - name: 'Diagnose: lldb crash autopsy (Intel)'
         if: matrix.runner == 'macos-15-large'
         continue-on-error: true
         timeout-minutes: 25
         run: |
-          set +e
-          ./target/release/solx-tester \
-            --solidity-compiler ./target/release/solx \
-            --path semanticTests \
-            --threads 1
-          ec=$?
-          if [ "$ec" -gt 128 ]; then
-            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
-          fi
-          exit "$ec"
+          lldb --batch \
+            -o run \
+            -k 'thread backtrace -c 25' \
+            -k 'disassemble --pc --count 12' \
+            -k 'register read rax rbx rcx rdx rsi rdi r8 r9 rip rsp' \
+            -k 'quit' \
+            -- ./target/release/solx-tester \
+              --solidity-compiler ./target/release/solx \
+              --path semanticTests \
+              --threads 1 \
+              --verbose
 
-      # macOS malloc debugging, no rebuild: freed memory is filled with 0x55,
-      # fresh allocations with 0xAA. If the crash pointer changes from 0x12…
-      # to one of those patterns, it is use-after-free / use-of-uninitialized
-      # respectively; guard pages may move the crash to the corrupting write.
-      - name: 'Diagnose: malloc scribble (Intel)'
-        if: matrix.runner == 'macos-15-large'
-        continue-on-error: true
-        timeout-minutes: 15
-        env:
-          MallocScribble: '1'
-          MallocPreScribble: '1'
-          MallocGuardEdges: '1'
-        run: |
-          set +e
-          ./target/release/solx-tester \
-            --solidity-compiler ./target/release/solx \
-            --path semanticTests
-          ec=$?
-          if [ "$ec" -gt 128 ]; then
-            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
-          fi
-          exit "$ec"
-
-      # AddressSanitizer names the exact allocation/free/use sites. Only
-      # solx-tester is instrumented (separate target dir, nightly rustc);
-      # the solx subprocess stays the stable release build.
-      - name: 'Diagnose: ASAN corpus run (Intel)'
-        if: matrix.runner == 'macos-15-large'
-        continue-on-error: true
-        timeout-minutes: 40
-        run: |
-          set +e
-          rustup toolchain install nightly --profile minimal || exit 1
-          RUSTFLAGS="-Zsanitizer=address" ${SFW_PREFIX:-} cargo +nightly build \
-            --release -p solx-tester --bin solx-tester \
-            --target x86_64-apple-darwin --target-dir target-asan || exit 1
-          ./target-asan/x86_64-apple-darwin/release/solx-tester \
-            --solidity-compiler ./target/release/solx \
-            --path semanticTests
-          ec=$?
-          if [ "$ec" -gt 128 ]; then
-            echo "::error::solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
-          fi
-          exit "$ec"
+      # Offline-symbolication backup for the recorded .ips offsets.
+      - name: Upload solx-tester binary
+        if: always() && matrix.runner == 'macos-15-large'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: solx-tester-binary-${{ matrix.runner }}
+          path: target/release/solx-tester
 
       - name: Collect crash reports and samples
         if: always()


### PR DESCRIPTION
# ⚠️ Temporary debug PR — do not merge

## Why

#524 (persistent worker subprocesses) needs macOS validation: worker-thread changes have a history of regressing badly on Mac while looking fine on Linux. #545 tried running the integration suite on large macOS runners on top of #524, and `solx-tester` was **signal-killed within seconds on `macos-15-large`** and **ran for hours without finishing on `macos-15-xlarge`** — but that run can't distinguish "solx-tester has never worked on macOS" from "#524 regressed on macOS". Notably, on the Intel runner **main's own binaries crashed identically** in the baseline-benchmark step, so at least the Intel crash predates #524.

This branch is plain `main`, so whatever it does on macOS **is** the macOS baseline:

- if main's tester also crashes/hangs here → the mac failures are pre-existing, #524 is off the hook (and we've found a real solx-tester mac bug);
- if main runs clean → re-point this branch at #524's tip and the diff is the regression, with diagnostics showing where.

## What it does

One push-triggered workflow (`mac-tester-debug.yaml`), matrix over `macos-15`, `macos-15-large`, `macos-15-xlarge`:

- **No C++ builds**: `build-llvm`/`build-solc` are called with test.yaml's exact macOS parameters, so both hit the finished-install caches saved on `main` (`v1-llvm-macOS-*`, `v1-solc-macOS-*`). Only the Rust workspace compiles; an iteration is ~15–20 min.
- **Signals get names**: `solx-tester` is invoked directly instead of via `solx-dev test solx-tester` — the wrapper collapses a signal death to `subprocess failed without exit code`; here the step prints e.g. `killed by signal 11 (SIGSEGV)`.
- **Symbols kept**: release binaries are built with `strip = none` + line tables so crash reports and `sample` output are readable; LLVM is RelWithDebInfo with assertions on.
- **Staged runs**: environment probe → single-test/single-thread smoke → full suite under a 30-minute watchdog that `sample`s the tester and its `--recursive-process` workers before killing them (for the xlarge-style hang).
- **Diagnostics**: new `.ips` crash reports from `~/Library/Logs/DiagnosticReports` and all `sample` outputs are printed and uploaded as a per-runner artifact.

Uses the `free-disk-space-macos` action from #533 (just merged), which with warm artifact caches usually skips the cleanup entirely.
