### PR TITLE
ci: cross-OS solx-tester suite on free macOS/Windows runners (ci:cross-os label + weekly cron)

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -4,10 +4,11 @@ description: >-
   checkout, Socket Firewall, platform prep (MSYS2 on Windows, disk cleanup
   on macOS), then the LLVM and solc builds. The build parameters below
   define the standard-config cache keys shared by test.yaml,
-  slang-tests.yaml, and cache-warmup.yaml — changing them here re-keys all
-  of those workflows together. Workflows needing a different LLVM
-  configuration (sanitizer, coverage, integration, release) call
-  build-llvm/build-solc directly and pair with their own cache-warmup job.
+  slang-tests.yaml, cross-os-tests.yaml, and cache-warmup.yaml — changing
+  them here re-keys all of those workflows together. Workflows needing a
+  different LLVM configuration (sanitizer, coverage, integration, release)
+  call build-llvm/build-solc directly and pair with their own cache-warmup
+  job.
 
 inputs:
   llvm:

--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -3,11 +3,12 @@ description: >-
   Shared CI prologue for the standard toolchain configuration: submodule
   checkout, Socket Firewall, platform prep (MSYS2 on Windows, disk cleanup
   on macOS), then the LLVM and solc builds. The build parameters below
-  define the standard-config cache keys shared by test.yaml and
-  cache-warmup.yaml — changing them here re-keys both workflows together.
-  Workflows needing a different LLVM configuration (sanitizer, coverage,
-  integration, release) call build-llvm and build-solc directly as needed
-  and pair with their own cache-warmup job.
+  define the standard-config cache keys shared by test.yaml,
+  cross-os-tests.yaml, and cache-warmup.yaml — changing them here re-keys
+  all of those workflows together. Workflows needing a different LLVM
+  configuration (sanitizer, coverage, integration, release) call build-llvm
+  and build-solc directly as needed and pair with their own cache-warmup
+  job.
 
 inputs:
   llvm:

--- a/.github/actions/run-tester-suite/action.yml
+++ b/.github/actions/run-tester-suite/action.yml
@@ -1,0 +1,174 @@
+name: Run solx-tester suite
+description: |
+  Builds solx and solx-tester and runs a smoke test plus a (optionally
+  filtered) suite under a watchdog. A run that neither crashes nor finishes
+  is diagnosed before being killed: on macOS the tester and its solx
+  processes are `sample`d and new crash reports are collected; elsewhere the
+  process table is snapshotted. Signal deaths are reported by name instead
+  of a bare exit code. Stage outcomes are aggregated at the end so
+  diagnostics always run.
+
+  The caller provides the toolchain: LLVM and solc must be built/restored,
+  and on Windows the msys2 shell must be prepared and the bundled static
+  libstdc++.a removed from the LLVM tree first (see solx#550).
+
+inputs:
+  target:
+    description: Cargo target triple to build for (empty = host default)
+    required: false
+    default: ''
+  path-filter:
+    description: solx-tester --path filter for the suite run (empty = full suite)
+    required: false
+    default: ''
+  watchdog-seconds:
+    description: Seconds before a still-running suite is diagnosed and killed
+    required: false
+    default: '1800'
+  diagnostics-name:
+    description: Artifact name for samples/crash reports (empty = tester-diagnostics-<os>)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install build target
+      if: inputs.target != ''
+      uses: ./.github/actions/setup-rust
+      with:
+        target: ${{ inputs.target }}
+
+    - name: Build solx and solx-tester
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        ${SFW_PREFIX:-} cargo fetch --locked
+        target_flag=""
+        if [ -n "${{ inputs.target }}" ]; then
+          target_flag="--target ${{ inputs.target }}"
+        fi
+        # shellcheck disable=SC2086 # target_flag is intentionally word-split
+        ${SFW_PREFIX:-} cargo build --frozen --release $target_flag \
+          --bin solx --bin solx-tester
+
+    - name: Locate binaries and mark crash-report baseline
+      shell: bash
+      run: |
+        dir="target/release"
+        if [ -n "${{ inputs.target }}" ]; then
+          dir="target/${{ inputs.target }}/release"
+        fi
+        ext=""
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          ext=".exe"
+        fi
+        echo "TESTER_SUITE_TESTER_BIN=./${dir}/solx-tester${ext}" >> "$GITHUB_ENV"
+        echo "TESTER_SUITE_SOLX_BIN=./${dir}/solx${ext}" >> "$GITHUB_ENV"
+        touch "${RUNNER_TEMP}/ips-baseline"
+
+    # solx-tester is invoked directly (not via `solx-dev test solx-tester`):
+    # the wrapper reduces a signal death to "subprocess failed without exit
+    # code", while here the signal is named. Stages record their exit codes
+    # instead of failing so diagnostics collection always runs; the final
+    # step delivers the verdict.
+    - name: Smoke test (one test, one thread)
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        set +e
+        "$TESTER_SUITE_TESTER_BIN" \
+          --solidity-compiler "$TESTER_SUITE_SOLX_BIN" \
+          --path tests/solidity/simple/default.sol \
+          --threads 1 \
+          --verbose
+        ec=$?
+        if [ "$ec" -gt 128 ]; then
+          echo "::error::smoke: solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+        fi
+        echo "TESTER_SUITE_SMOKE_EC=$ec" >> "$GITHUB_ENV"
+        exit 0
+
+    - name: Suite run under watchdog
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        set +e
+        args=()
+        if [ -n "${{ inputs.path-filter }}" ]; then
+          args+=(--path "${{ inputs.path-filter }}")
+        fi
+        start=$(date +%s)
+        "$TESTER_SUITE_TESTER_BIN" --solidity-compiler "$TESTER_SUITE_SOLX_BIN" "${args[@]}" &
+        PID=$!
+        elapsed=0
+        ec=0
+        while kill -0 "$PID" 2>/dev/null; do
+          if [ "$elapsed" -ge "${{ inputs.watchdog-seconds }}" ]; then
+            echo "::error::suite still running after ${elapsed}s; capturing diagnostics, then killing"
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              pgrep -fl 'solx' || true
+              sample "$PID" 10 -file solx-tester-hang.sample.txt || true
+              # Top-level solx parents AND pooled workers: the #524 old-tip
+              # hang showed the parents are where a wedge hides.
+              for p in $(pgrep -x solx | head -5); do
+                sample "$p" 5 -file "solx-parent-${p}.sample.txt" || true
+              done
+              for p in $(pgrep -f -- '--recursive-process' | head -5); do
+                sample "$p" 5 -file "solx-worker-${p}.sample.txt" || true
+              done
+            elif [ "$RUNNER_OS" = "Windows" ]; then
+              tasklist | grep -i "solx" || echo "(no solx processes in tasklist)"
+            else
+              ps -ef | grep -i "solx" | grep -v grep || true
+            fi
+            kill -9 "$PID"
+            if [ "$RUNNER_OS" = "Windows" ]; then
+              taskkill //F //IM solx.exe //T 2>/dev/null || true
+              taskkill //F //IM solx-tester.exe //T 2>/dev/null || true
+            fi
+            ec=124
+            break
+          fi
+          sleep 30
+          elapsed=$((elapsed + 30))
+        done
+        if [ "$ec" -ne 124 ]; then
+          wait "$PID"
+          ec=$?
+          echo "suite finished in $(( $(date +%s) - start ))s with exit code $ec"
+          if [ "$ec" -gt 128 ]; then
+            echo "::error::suite: solx-tester killed by signal $((ec - 128)) (SIG$(kill -l $((ec - 128))))"
+          fi
+        fi
+        echo "TESTER_SUITE_SUITE_EC=$ec" >> "$GITHUB_ENV"
+        exit 0
+
+    - name: Collect crash reports and samples
+      shell: bash
+      run: |
+        mkdir -p tester-diagnostics
+        cp ./*.sample.txt tester-diagnostics/ 2>/dev/null || true
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          find "${HOME}/Library/Logs/DiagnosticReports" -type f -newer "${RUNNER_TEMP}/ips-baseline" 2>/dev/null \
+            | while read -r report; do
+                echo "=== ${report} ==="
+                head -c 20000 "${report}"
+                echo
+                cp "${report}" tester-diagnostics/ || true
+              done
+        fi
+        ls -la tester-diagnostics/ || true
+
+    - name: Upload diagnostics
+      if: hashFiles('tester-diagnostics/*') != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.diagnostics-name != '' && inputs.diagnostics-name || format('tester-diagnostics-{0}', runner.os) }}
+        path: tester-diagnostics/
+
+    - name: Verdict
+      shell: bash
+      run: |
+        echo "smoke exit code: ${TESTER_SUITE_SMOKE_EC}, suite exit code: ${TESTER_SUITE_SUITE_EC}"
+        if [ "${TESTER_SUITE_SMOKE_EC}" = "0" ] && [ "${TESTER_SUITE_SUITE_EC}" = "0" ]; then
+          exit 0
+        fi
+        exit 1

--- a/.github/workflows/cross-os-tests.yaml
+++ b/.github/workflows/cross-os-tests.yaml
@@ -1,0 +1,99 @@
+name: Cross-OS Tests
+
+# Runs the full solx-tester suite on free macOS/Windows runners. Cross-OS
+# legs test platform behavior — process management, IPC, paths, toolchain
+# quirks — not output quality, which stays on the Linux integration suite;
+# Hardhat/Foundry are deliberately not replicated here.
+#
+# Rationale: the suite caught two real platform-only bugs in one week — the
+# #524 worker-pool hang on macOS (fixed before merge) and the rustc 1.96.1
+# enum-niche miscompile (#547) — both invisible on Linux. Windows had never
+# executed solx-tester before this workflow's spike (74,605 cases green,
+# ~16 min, run 29426196846).
+#
+# The build-toolchain action keeps the toolchain params identical to
+# test.yaml's legs, so LLVM/solc come from the finished-install caches
+# saved on main (v1-llvm-*, v1-solc-*).
+#
+# TODO(Stage 3): before opening the PR, switch the trigger to
+# pull_request label `ci:cross-os` + workflow_dispatch + weekly cron on
+# main. The push trigger below is temporary, for verification runs on this
+# branch.
+
+on:
+  push:
+    branches:
+      - cross-os-tester
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tester:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Full-suite baselines: macos-15 ≈ 10–15 min; windows-2025 corpus
+          # 14 min + complex 1.5 min (spike runs 29374444399, 29426196846).
+          # Watchdogs sized ~2x so a trip means pathology, not slowness.
+          - runner: macos-15
+            watchdog-seconds: '2700'
+          - runner: windows-2025
+            target: x86_64-pc-windows-gnu
+            watchdog-seconds: '4500'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 150
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUST_BACKTRACE: full
+      # Keep symbols (Cargo.toml sets strip = true) so crash reports and
+      # `sample` output are readable.
+      CARGO_PROFILE_RELEASE_STRIP: none
+      CARGO_PROFILE_RELEASE_DEBUG: line-tables-only
+      BOOST_PREFIX: ${{ github.workspace }}/solx-solidity/boost/lib
+      SOLC_PREFIX: ${{ github.workspace }}/solx-solidity/build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Build toolchain
+        uses: ./.github/actions/build-toolchain
+
+      # Read-only restore of test.yaml's cache; prefix and step position
+      # (after build-toolchain, so the key sees the same post-msys rustup
+      # host) must match test.yaml or the keys diverge.
+      - name: Cache cargo artifacts
+        if: runner.os == 'Windows'
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: build-and-test-v2
+          cache-on-failure: true
+          save-if: 'false'
+
+      # The Windows disk cannot hold LLVM sources, build trees, and a Rust
+      # workspace build at once. Unlike test.yaml's variant, solx-solidity's
+      # test/ is kept: the Ethereum corpus is read from it at run time.
+      - name: Free disk space (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "Before cleanup:" && df -h .
+          rm -rf solx-llvm target-llvm/build-final
+          find solx-solidity -mindepth 1 -maxdepth 1 ! -name build ! -name boost ! -name test -exec rm -rf {} +
+          rm -rf .git/modules
+          echo "After cleanup:" && df -h .
+
+      - name: Run tester suite
+        uses: ./.github/actions/run-tester-suite
+        with:
+          target: ${{ matrix.target || '' }}
+          watchdog-seconds: ${{ matrix.watchdog-seconds }}
+          diagnostics-name: tester-diagnostics-${{ matrix.runner }}

--- a/.github/workflows/cross-os-tests.yaml
+++ b/.github/workflows/cross-os-tests.yaml
@@ -13,27 +13,34 @@ name: Cross-OS Tests
 #
 # The build-toolchain action keeps the toolchain params identical to
 # test.yaml's legs, so LLVM/solc come from the finished-install caches
-# saved on main (v1-llvm-*, v1-solc-*).
+# saved on main (v1-llvm-*, v1-solc-*). Verified end-to-end on run
+# 29429860239 (macos-15 ~22 min, windows-2025 ~37 min, full suites green
+# on the free runners).
 #
-# TODO(Stage 3): before opening the PR, switch the trigger to
-# pull_request label `ci:cross-os` + workflow_dispatch + weekly cron on
-# main. The push trigger below is temporary, for verification runs on this
-# branch.
+# Triggers: the `ci:cross-os` PR label for on-demand validation of
+# platform-sensitive changes, workflow_dispatch, and a weekly cron on main
+# as a drift net. Advisory only — do not make this a required check
+# (label-gated required checks can hang the merge queue).
 
 on:
-  push:
-    branches:
-      - cross-os-tester
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC, on main.
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   tester:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:cross-os')
+    name: tester (${{ matrix.runner }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cross-os-tests.yaml
+++ b/.github/workflows/cross-os-tests.yaml
@@ -7,9 +7,9 @@ name: Cross-OS Tests
 #
 # Rationale: the suite caught two real platform-only bugs in one week — the
 # #524 worker-pool hang on macOS (fixed before merge) and the rustc 1.96.1
-# enum-niche miscompile (#547) — both invisible on Linux. Windows had never
-# executed solx-tester before this workflow's spike (74,605 cases green,
-# ~16 min, run 29426196846).
+# enum-niche miscompile (#547, fixed by the 1.97.1 bump in #556) — both
+# invisible on Linux. Windows had never executed solx-tester before this
+# workflow's spike (74,605 cases green, ~16 min, run 29426196846).
 #
 # The build-toolchain action keeps the toolchain params identical to
 # test.yaml's legs, so LLVM/solc come from the finished-install caches
@@ -53,8 +53,15 @@ jobs:
           - runner: windows-2025
             target: x86_64-pc-windows-gnu
             watchdog-seconds: '4500'
+          # No 1.97.1-era full-suite timing exists for the free Intel minis
+          # (pre-fix the suite exceeded 75 min without finishing), so this
+          # leg's watchdog and timeout are a probe budget, not a 2x margin —
+          # tighten both once real runs establish a baseline.
+          - runner: macos-15-intel
+            watchdog-seconds: '6600'
+            timeout-minutes: 240
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 150
+    timeout-minutes: ${{ matrix.timeout-minutes || 150 }}
     env:
       CARGO_INCREMENTAL: "0"
       RUST_BACKTRACE: full

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Tests live in `tests/solidity/`, `tests/yul/`, `tests/llvm-ir/`.
 - `ci:slang` — enable Slang tests
 - `ci:sanitizer` — enable address sanitizer tests
 - `ci:integration` — enable integration tests
+- `ci:cross-os` — run the solx-tester suite on macOS/Windows runners (also runs weekly on main)
 
 ## Renovate Config
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ Tests live in `tests/solidity/`, `tests/yul/`, `tests/llvm-ir/`.
 
 - `ci:sanitizer` — enable address sanitizer tests
 - `ci:integration` — enable integration tests
+- `ci:cross-os` — run the solx-tester suite on macOS/Windows runners (also runs weekly on main)
 
 ## Renovate Config
 


### PR DESCRIPTION
## What

A label-gated + weekly-cron workflow running the **full `solx-tester` suite on free macOS (arm64 + Intel) and Windows runners**, plus the `run-tester-suite` composite action it is built from. The workflow consumes the `build-toolchain` composite (landed separately in #581) for its standard-config LLVM/solc prologue, so it adds no toolchain-build steps of its own.

- **Triggers**: PR label `ci:cross-os` (on-demand, for platform-sensitive changes like process/IPC work), `workflow_dispatch`, and a Monday 06:00 UTC cron on main as a drift net. Advisory only — must never become a required check.
- **Scope**: solx-tester only. Cross-OS legs test *platform behavior* (process management, IPC, paths, toolchain quirks); output quality stays on the Linux integration suite, and Hardhat/Foundry are deliberately not replicated.
- **Cost**: $0 — `macos-15`, `macos-15-intel`, and `windows-2025` are free for public repos; LLVM/solc come from the finished-install caches saved on main, so nothing heavier than the Rust workspace compiles.

## Depends on

**#581 (merged)** — extracted the standard-config toolchain prologue (submodules → SFW → msys → macOS-disk → LLVM → solc) into the shared `build-toolchain` composite. This workflow is its sixth consumer; the only change to the composite here is adding `cross-os-tests.yaml` to its consumer-list description. #581 also folded in #550's fix option 2, so the bundled static `libstdc++.a` drop now happens *inside* `build-toolchain` for every standard-config Windows build — this workflow inherits the working shared-`libstdc++` link with no step of its own.

## Why

One week of evidence that this layer catches what Linux cannot:

- the #524 worker-pool hang on macOS (present at an intermediate tip, fixed before merge — confirmed by this harness's watchdog samples, [PR comment](https://github.com/NomicFoundation/solx/pull/524#issuecomment-4980190960));
- the rustc 1.96.1 enum-niche miscompile killing solx-tester on Intel macs (#547, since fixed by the 1.97.1 bump in #556 — the Intel leg here is what keeps verifying it, since test.yaml's Intel leg never runs solx-tester);
- the Windows libstdc++ link fragility (#550), found the day this workflow first ran solx-tester on Windows — which had **zero prior executions** there; it passed 74,605 cases once the `libstdc++` drop (now in `build-toolchain`) and the corpus-dir retention below were in place.

## How it works

`run-tester-suite` (composite action): builds solx + solx-tester (symbols kept), smoke test, then the suite under a parametrized watchdog. A run that neither crashes nor finishes gets diagnosed before the kill — on macOS, `sample` stacks of the tester, the top-level solx parents, *and* the pooled workers, plus new crash reports from `DiagnosticReports`; on Windows, a `tasklist` snapshot. Signal deaths are reported by name (`killed by signal 11 (SIGSEGV)`) instead of the `solx-dev` wrapper's "subprocess failed without exit code". Stage outcomes are aggregated at the end so diagnostics always run.

Windows specifics:
- the bundled static `libstdc++.a` drop (#550) is **inherited from `build-toolchain`**, applied to all standard-config Windows test builds — not a step this workflow adds;
- keep `solx-solidity/test/` through the disk cleanup (the Ethereum corpus is read from it at run time) — this workflow's own `Free disk space (Windows)` step.

## Verification

[Run 29429860239](https://github.com/NomicFoundation/solx/actions/runs/29429860239): `macos-15` and `windows-2025` legs green, full suites — ~22 min and ~37 min job time respectively. That run predates the rebase onto `build-toolchain`, but the composite encodes byte-identical LLVM/solc params, so the tester results carry over; a fresh `ci:cross-os` run on the rebased branch confirms the composite path.

The `macos-15-intel` leg has no post-1.97.1 timing yet (pre-fix runs exceeded 75 min without finishing), so its watchdog (110 min) and job timeout (240 min) are a probe budget rather than the ~2x margin the other legs get. First runs establish the baseline; then tighten, or scope down to `--path tests/solidity` if the full suite can't finish on the free Intel minis.

## Follow-ups (not in this PR)

- Tune the Intel leg's watchdog/timeout once real runs establish a full-suite baseline (see Verification).
- #550's durable fix (option 1): stop bundling `libstdc++.a` into the LLVM tree in solx-dev and make release packaging link it statically on its own. That's a solx-dev + release.yaml change whose verification surface is a release build, so it stays out of CI-only work like this. When it lands, `build-toolchain`'s drop step gets deleted — and its plain `rm` fails loudly if the bundling disappears first, so the workaround can't linger silently.
- The `mac-tester-debug*` / `win-tester-spike` branches and #546 get retired once this lands.
