### PR TITLE
feat(slang): libraries and using for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,7 +2765,7 @@ checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 [[package]]
 name = "melior"
 version = "0.26.9"
-source = "git+https://github.com/NomicFoundation/melior?rev=d188691b0620f91ff83e98cdbdf60507b2ee37d9#d188691b0620f91ff83e98cdbdf60507b2ee37d9"
+source = "git+https://github.com/NomicFoundation/melior?rev=f780c87b43f3015176ba919f7749c655cc13685e#f780c87b43f3015176ba919f7749c655cc13685e"
 dependencies = [
  "melior-macro",
  "mlir-sys",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "melior-macro"
 version = "0.19.5"
-source = "git+https://github.com/NomicFoundation/melior?rev=d188691b0620f91ff83e98cdbdf60507b2ee37d9#d188691b0620f91ff83e98cdbdf60507b2ee37d9"
+source = "git+https://github.com/NomicFoundation/melior?rev=f780c87b43f3015176ba919f7749c655cc13685e#f780c87b43f3015176ba919f7749c655cc13685e"
 dependencies = [
  "comrak",
  "convert_case 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4611,12 +4611,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=ad18c38a0af62abbcfb77ea55087184aa0d1eba5#ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -4857,14 +4857,12 @@ name = "solx-slang"
 version = "0.1.7"
 dependencies = [
  "anyhow",
- "itertools 0.15.0",
  "num",
  "num-traits",
  "ruint",
  "semver 1.0.28",
  "serde_json",
  "slang_solidity_v2",
- "solx-codegen-evm",
  "solx-core",
  "solx-mlir",
  "solx-standard-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "ad18c38a0af62abbcfb77ea55087184aa0d1eba5"
+rev = "a1ade1c6642d2535fdb107848759b41341bbb205"

--- a/solx-core/src/project/contract/mod.rs
+++ b/solx-core/src/project/contract/mod.rs
@@ -516,8 +516,25 @@ impl Contract {
                 };
 
                 let melior = solx_mlir::Context::create_melior_context();
-                let raw_llvm = solx_mlir::Context::translate_source_to_llvm(&melior, &mlir.source)
-                    .context("MLIR translation")?;
+                // The deploy code of a failed runtime build still compiles, against a
+                // placeholder offset, so its own errors surface.
+                // TODO: support user-declared immutables, whose offsets the runtime build
+                // records per name beside the library address tag.
+                let immutables = match code_segment {
+                    solx_utils::CodeSegment::Deploy => immutables.unwrap_or_else(|| {
+                        BTreeMap::from([(
+                            solx_codegen_evm::LIBRARY_DEPLOY_ADDRESS_TAG.to_owned(),
+                            BTreeSet::from([0]),
+                        )])
+                    }),
+                    solx_utils::CodeSegment::Runtime => BTreeMap::new(),
+                };
+                let raw_llvm = solx_mlir::Context::translate_source_to_llvm(
+                    &melior,
+                    &mlir.source,
+                    &immutables,
+                )
+                .context("MLIR translation")?;
                 let context = unsafe { inkwell::context::Context::new(raw_llvm.context) };
                 let module = unsafe { inkwell::module::Module::new(raw_llvm.module) };
                 module.set_name(code_identifier.as_str());
@@ -571,7 +588,9 @@ impl Contract {
                 )?;
                 let (immutables_out, metadata_out) = match code_segment {
                     solx_utils::CodeSegment::Deploy => (None, None),
-                    solx_utils::CodeSegment::Runtime => (Some(BTreeMap::new()), metadata_bytes),
+                    solx_utils::CodeSegment::Runtime => {
+                        (Some(build.immutables.unwrap_or_default()), metadata_bytes)
+                    }
                 };
                 let object = EVMContractObject::new(
                     code_identifier,

--- a/solx-mlir/Cargo.toml
+++ b/solx-mlir/Cargo.toml
@@ -16,7 +16,7 @@ num.workspace = true
 ruint.workspace = true
 
 inkwell = { workspace = true, features = ["llvm21-1-no-llvm-linking"] }
-melior = { git = "https://github.com/NomicFoundation/melior", rev = "d188691b0620f91ff83e98cdbdf60507b2ee37d9", features = ["ods-dialects", "helpers"] }
+melior = { git = "https://github.com/NomicFoundation/melior", rev = "f780c87b43f3015176ba919f7749c655cc13685e", features = ["ods-dialects", "helpers"] }
 serde.workspace = true
 # mlir-sys 210 wraps LLVM 21.0 C API; llvm-sys (via inkwell) targets 21.1.
 # Both are built from the same LLVM source tree (LLVM_SYS_211_PREFIX ==

--- a/solx-mlir/src/context/mod.rs
+++ b/solx-mlir/src/context/mod.rs
@@ -6,6 +6,9 @@ pub mod contract;
 pub mod environment;
 pub mod function;
 
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::ffi::CString;
 use std::sync::Once;
 
 use melior::dialect::DialectRegistry;
@@ -264,7 +267,8 @@ impl<'context> Context<'context> {
 
     /// Translate MLIR source text (LLVM dialect) to raw LLVM pointers.
     ///
-    /// Parses the source, verifies it, and translates to LLVM IR.
+    /// Parses the source, verifies it, lowers each `llvm.setimmutable` into heap stores at its
+    /// id's `immutables` offsets, and translates to LLVM IR.
     /// Returns owned `(LLVMContextRef, LLVMModuleRef)`.
     ///
     /// # Errors
@@ -274,6 +278,7 @@ impl<'context> Context<'context> {
     pub fn translate_source_to_llvm(
         melior: &melior::Context,
         source: &str,
+        immutables: &BTreeMap<String, BTreeSet<u64>>,
     ) -> anyhow::Result<RawLlvmModule> {
         let module = Module::parse(melior, source)
             .ok_or_else(|| anyhow::anyhow!("failed to parse MLIR source text"))?;
@@ -282,7 +287,24 @@ impl<'context> Context<'context> {
             anyhow::bail!("MLIR module verification failed");
         }
 
+        let ids: Vec<CString> = immutables
+            .keys()
+            .map(|id| CString::new(id.as_str()).expect("an immutable id carries no NUL byte"))
+            .collect();
+        let (id_pointers, offsets): (Vec<*const std::ffi::c_char>, Vec<u64>) = ids
+            .iter()
+            .zip(immutables.values())
+            .flat_map(|(id, offsets)| offsets.iter().map(|offset| (id.as_ptr(), *offset)))
+            .unzip();
+
         unsafe {
+            crate::ffi::mlirEvmLowerSetImmutables(
+                module.to_raw(),
+                id_pointers.as_ptr(),
+                offsets.as_ptr(),
+                offsets.len() as u64,
+            );
+
             let raw_operation = module.as_operation().to_raw();
             let llvm_context = inkwell::llvm_sys::core::LLVMContextCreate();
 

--- a/solx-mlir/src/ffi.rs
+++ b/solx-mlir/src/ffi.rs
@@ -9,6 +9,7 @@
 use mlir_sys::MlirContext;
 use mlir_sys::MlirDialectHandle;
 use mlir_sys::MlirDialectRegistry;
+use mlir_sys::MlirModule;
 use mlir_sys::MlirPass;
 
 unsafe extern "C" {
@@ -217,4 +218,16 @@ unsafe extern "C" {
         base_addr_ty: mlir_sys::MlirType,
         element_type: mlir_sys::MlirType,
     ) -> mlir_sys::MlirType;
+
+    // ---- Solidity immutables lowering ----
+
+    /// Lowers each `llvm.setimmutable` into heap stores at its id's offsets, taken from the
+    /// parallel `ids`/`offsets` arrays of `count` pairs, and erases every one it walks: an id
+    /// absent from the arrays stores nothing.
+    pub fn mlirEvmLowerSetImmutables(
+        module: MlirModule,
+        ids: *const *const std::ffi::c_char,
+        offsets: *const u64,
+        count: u64,
+    );
 }

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -207,26 +207,30 @@ sol_ops! {
         CallOperation.callee(symbol_attr(&callee.mlir_name))
             .outs(many(callee.function_type.results)).operands(many(operands))
     }
-    Function::external_call | external_static_call | external_try_call | external_static_try_call
-    | library_call | library_static_call | library_try_call | library_static_try_call (
+    Function::external_call(
         callee: function, arguments: values, result_types: types,
         address: value, selector: value, gas: value, amount: value,
+        library: flag, static_call: flag, try_call: flag,
     ) -> status_and_values {
         ExtCallOperation.callee(str_attr(&callee.mlir_name)).ins(many(arguments)).addr(address)
             .gas(gas).val(amount).selector(selector)
             .callee_type(ty_attr(signature(callee)))
             .status(boolean()).outs(many(result_types))
-    } flagged .static_call, .try_call; mode .delegate_call, .library_call;
+            .delegate_call(library).library_call(library)
+            .static_call(static_call).try_call(try_call)
+    }
 
     Value::indirect_call(self, operands: values, result_types: types) -> values {
         ICallOperation.callee(self).outs(many(result_types)).callee_operands(many(operands))
     }
-    Value::external_call | external_static_call | external_try_call | external_static_try_call (
+    Value::external_call(
         self, operands: values, result_types: types, gas: value, amount: value,
+        static_call: flag, try_call: flag,
     ) -> status_and_values {
         ExtICallOperation.callee(self).outs(status_and(result_types))
             .callee_operands(many(operands)).gas(gas).value(amount)
-    } flagged .static_call, .try_call;
+            .static_call(static_call).try_call(try_call)
+    }
     Value::create_contract | create_contract_try (
         object_name: str, amount: value, salt: optional_value, arguments: values, result_type: ty,
     ) -> value {

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -160,6 +160,9 @@ sol_ops! {
     Value::object_code(object_name: str) -> value {
         ObjectCodeOperation.obj_name(str_attr(object_name)).out(memory())
     }
+    Value::library_address(object_name: str) -> value {
+        LibAddrOperation._name(str_attr(object_name)).val(address())
+    }
     Value::bare_call(address: value, gas: value, amount: value, input: value) -> values {
         BareCallOperation.addr(address).gas(gas).val(amount).inp(input)
             .status(boolean()).ret_data(memory())
@@ -204,15 +207,17 @@ sol_ops! {
         CallOperation.callee(symbol_attr(&callee.mlir_name))
             .outs(many(callee.function_type.results)).operands(many(operands))
     }
-    Function::external_call | external_static_call | external_try_call | external_static_try_call (
-        callee: function, arguments: values,
+    Function::external_call | external_static_call | external_try_call | external_static_try_call
+    | library_call | library_static_call | library_try_call | library_static_try_call (
+        callee: function, arguments: values, result_types: types,
         address: value, selector: value, gas: value, amount: value,
     ) -> status_and_values {
         ExtCallOperation.callee(str_attr(&callee.mlir_name)).ins(many(arguments)).addr(address)
             .gas(gas).val(amount).selector(selector)
             .callee_type(ty_attr(signature(callee)))
-            .status(boolean()).outs(many(callee.function_type.results))
-    } flagged .static_call, .try_call;
+            .status(boolean()).outs(many(result_types))
+    } flagged .static_call, .try_call; mode .delegate_call, .library_call;
+
     Value::indirect_call(self, operands: values, result_types: types) -> values {
         ICallOperation.callee(self).outs(many(result_types)).callee_operands(many(operands))
     }

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -391,6 +391,27 @@ macro_rules! sol_ops {
 
     (
         $receiver:ident :: $base:ident | $flagged:ident | $guarded:ident | $guarded_flagged:ident
+        | $mode:ident | $mode_flagged:ident | $mode_guarded:ident | $mode_guarded_flagged:ident
+        ($($parameters:tt)*)
+        -> $disposition:ident { $operation:ident $($chain:tt)* }
+        flagged .$setter:ident, .$guard:ident ; mode $(.$mode_flag:ident),+ ;
+        $($rest:tt)*
+    ) => {
+        sol_ops!(
+            $receiver :: $base | $flagged | $guarded | $guarded_flagged ($($parameters)*)
+            -> $disposition { $operation $($chain)* } flagged .$setter, .$guard;
+        );
+        sol_ops!(
+            $receiver :: $mode | $mode_flagged | $mode_guarded | $mode_guarded_flagged
+            ($($parameters)*)
+            -> $disposition { $operation $($chain)* $(.$mode_flag(unit_flag))+ }
+            flagged .$setter, .$guard;
+        );
+        sol_ops!($($rest)*);
+    };
+
+    (
+        $receiver:ident :: $base:ident | $flagged:ident | $guarded:ident | $guarded_flagged:ident
         ($($parameters:tt)*)
         -> $disposition:ident { $operation:ident $($chain:tt)* }
         flagged .$setter:ident, .$guard:ident ;

--- a/solx-mlir/src/macros.rs
+++ b/solx-mlir/src/macros.rs
@@ -171,8 +171,8 @@ impl<'slice, T, const N: usize> IntoOds<&'slice [T]> for &'slice [T; N] {
 /// identifier is always a parameter.
 ///
 /// A `base | flagged (…) … { … } flagged .setter ;` declaration stamps a pair of methods off one
-/// chain: `base` omits the unit-flag setter and `flagged` appends `.setter(unit_flag)`, so a binary
-/// mode is two named methods rather than one method taking a `bool`.
+/// chain: `base` omits the unit-flag setter and `flagged` appends `.setter(unit_flag)`, naming a
+/// statically chosen mode; a runtime-selected flag is a `flag` parameter instead.
 ///
 /// Dispositions: `-> value` / `-> place` append at the `current_block()` cursor and wrap the single
 /// result; `-> value nop_if_same(param)` short-circuits when the receiver already has that type;
@@ -186,6 +186,7 @@ macro_rules! sol_ops {
     () => {};
 
     (@ty i64) => { i64 };
+    (@ty flag) => { bool };
     (@ty str) => { &str };
     (@ty bytes) => { &[u8] };
     (@ty value) => { $crate::Value<'context> };
@@ -278,7 +279,7 @@ macro_rules! sol_ops {
 
     (@chain $builder:ident [$context:ident] [$receiver:tt]) => { $builder };
     (@chain $builder:ident [$context:ident] [$receiver:tt] .$setter:ident (unit_flag) $($rest:tt)*) => {{
-        let $builder = $builder.$setter(::melior::ir::Attribute::unit($context.melior));
+        let $builder = $builder.$setter(true);
         sol_ops!(@chain $builder [$context] [$receiver] $($rest)*)
     }};
     (@chain $builder:ident [$context:ident] [$receiver:tt] .$setter:ident (optional_str($text:ident)) $($rest:tt)*) => {{
@@ -388,45 +389,6 @@ macro_rules! sol_ops {
         let mut results = sol_ops!(@emit values [$context] $operation, $message);
         (results.remove(0), results)
     }};
-
-    (
-        $receiver:ident :: $base:ident | $flagged:ident | $guarded:ident | $guarded_flagged:ident
-        | $mode:ident | $mode_flagged:ident | $mode_guarded:ident | $mode_guarded_flagged:ident
-        ($($parameters:tt)*)
-        -> $disposition:ident { $operation:ident $($chain:tt)* }
-        flagged .$setter:ident, .$guard:ident ; mode $(.$mode_flag:ident),+ ;
-        $($rest:tt)*
-    ) => {
-        sol_ops!(
-            $receiver :: $base | $flagged | $guarded | $guarded_flagged ($($parameters)*)
-            -> $disposition { $operation $($chain)* } flagged .$setter, .$guard;
-        );
-        sol_ops!(
-            $receiver :: $mode | $mode_flagged | $mode_guarded | $mode_guarded_flagged
-            ($($parameters)*)
-            -> $disposition { $operation $($chain)* $(.$mode_flag(unit_flag))+ }
-            flagged .$setter, .$guard;
-        );
-        sol_ops!($($rest)*);
-    };
-
-    (
-        $receiver:ident :: $base:ident | $flagged:ident | $guarded:ident | $guarded_flagged:ident
-        ($($parameters:tt)*)
-        -> $disposition:ident { $operation:ident $($chain:tt)* }
-        flagged .$setter:ident, .$guard:ident ;
-        $($rest:tt)*
-    ) => {
-        sol_ops!(
-            $receiver :: $base | $flagged ($($parameters)*)
-            -> $disposition { $operation $($chain)* } flagged .$setter;
-        );
-        sol_ops!(
-            $receiver :: $guarded | $guarded_flagged ($($parameters)*)
-            -> $disposition { $operation $($chain)* .$guard(unit_flag) } flagged .$setter;
-        );
-        sol_ops!($($rest)*);
-    };
 
     (
         $receiver:ident :: $base:ident | $flagged:ident ($($parameters:tt)*)

--- a/solx-mlir/tests/lit/abi_coding.sol
+++ b/solx-mlir/tests/lit/abi_coding.sol
@@ -76,6 +76,10 @@
 // CHECK: sol.func @{{.*decodeCalldata.*}}
 // CHECK:   sol.decode %{{.*}} : !sol.string<CallData> -> ui256
 
+// CHECK: sol.func @{{.*decodeLibrary.*}}
+// CHECK:   %[[LIB:.*]] = sol.decode %{{.*}} : !sol.string<Memory> -> !sol.contract<{{.*Lib.*}}>
+// CHECK:   sol.address_cast %[[LIB]] : !sol.contract<{{.*Lib.*}}> to !sol.address
+
 contract C {
     bytes stored;
 
@@ -112,6 +116,8 @@ contract C {
     function decodeStorage() public view returns (uint256) { return abi.decode(stored, (uint256)); }
 
     function decodeCalldata(bytes calldata data) public pure returns (uint256) { return abi.decode(data, (uint256)); }
+
+    function decodeLibrary(bytes memory data) public pure returns (address) { return address(abi.decode(data, (Lib))); }
 }
 
 interface I {
@@ -119,3 +125,5 @@ interface I {
 
     function n() external returns (uint256);
 }
+
+library Lib {}

--- a/solx-mlir/tests/lit/getter_constant_member.sol
+++ b/solx-mlir/tests/lit/getter_constant_member.sol
@@ -3,15 +3,17 @@
 // Public-constant auto-getter whose initializer reads a library constant member:
 // solc's print-init crashes (SIGSEGV), so this is solx-only.
 
-// CHECK: sol.func @{{.*DERIVED.*}}() -> ui256 attributes {{.*}}selector = 1646776813 : i32{{.*}}#Pure
-// CHECK:   %[[C:.*]] = sol.constant 7 : ui8
-// CHECK:   %[[V:.*]] = sol.cast %[[C]] : ui8 to ui256
-// CHECK:   sol.return %[[V]] : ui256
-
-library Library {
-    uint256 internal constant BASE = 7;
-}
+// CHECK: sol.contract @{{.*C.*}} {
+// CHECK: sol.func @{{.*DERIVED.*}}() -> ui256 attributes {orig_fn_type = () -> ui256, selector = 1646776813 : i32, state_mutability = #Pure}
+// CHECK:   %[[CONSTANT:.*]] = sol.constant 7 : ui8
+// CHECK:   %[[VALUE:.*]] = sol.cast %[[CONSTANT]] : ui8 to ui256
+// CHECK:   sol.return %[[VALUE]] : ui256
+// CHECK: } {kind = #Contract}
 
 contract C {
     uint256 public constant DERIVED = Library.BASE;
+}
+
+library Library {
+    uint256 internal constant BASE = 7;
 }

--- a/solx-mlir/tests/lit/internal_function_pointer.sol
+++ b/solx-mlir/tests/lit/internal_function_pointer.sol
@@ -67,6 +67,12 @@
 // CHECK:   %[[POINTER:.*]] = sol.load %[[SLOT]] : !sol.ptr<!sol.func_ref<(ui256, ui256) -> (ui256, ui256)>, Stack>, !sol.func_ref<(ui256, ui256) -> (ui256, ui256)>
 // CHECK:   sol.icall %[[POINTER]](%{{.*}}, %{{.*}}) : !sol.func_ref<(ui256, ui256) -> (ui256, ui256)>, (ui256, ui256) -> (ui256, ui256)
 
+// CHECK: sol.contract @{{.*Lib.*}} {
+// CHECK: sol.func @{{.*run_library.*}}
+// CHECK:   sol.func_constant @{{.*double.*}} : !sol.func_ref<(ui256) -> ui256>
+// CHECK:   sol.icall %{{[0-9]+}}(%{{.*}}) : !sol.func_ref<(ui256) -> ui256>, (ui256) -> ui256
+// CHECK: } {kind = #Library}
+
 contract C {
     struct S {
         function () internal returns (uint256) f;
@@ -148,5 +154,16 @@ contract C {
     function run_arguments_results() public returns (uint256, uint256) {
         function (uint256, uint256) internal returns (uint256, uint256) functionPointer = pair;
         return functionPointer(7, 9);
+    }
+}
+
+library Lib {
+    function double(uint256 a) internal pure returns (uint256) {
+        return a * 2;
+    }
+
+    function run_library(uint256 x) internal pure returns (uint256) {
+        function (uint256) internal pure returns (uint256) functionPointer = double;
+        return functionPointer(x);
     }
 }

--- a/solx-mlir/tests/lit/library_abi.sol
+++ b/solx-mlir/tests/lit/library_abi.sol
@@ -1,0 +1,66 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*qualified_calldata_argument.*}}
+// CHECK:   sol.ext_call "{{.*look.*}}"(%{{.*}}) at %{{.*}} gas %{{.*}} value %c0_ui256 selector %c1335285351_ui256 {callee_type = (!sol.string<Memory>) -> ui256, delegate_call, library_call, static_call} : !sol.address, (!sol.string<CallData>) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*qualified_calldata_return.*}}
+// CHECK:   sol.ext_call "{{.*tail.*}}"(%{{.*}}) at %{{.*}} gas %{{.*}} value %c0_ui256 selector %c3126462307_ui256 {callee_type = (!sol.string<Memory>) -> !sol.string<Memory>, delegate_call, library_call, static_call} : !sol.address, (!sol.string<CallData>) -> (i1, !sol.string<Memory>)
+
+// CHECK: sol.func @{{.*qualified_storage.*}}
+// CHECK:   %[[SLOT:.*]] = sol.addr_of @{{.*stored.*}} : !sol.string<Storage>
+// CHECK:   sol.ext_call "{{.*keep.*}}"(%[[SLOT]]) at %{{.*}} gas %{{.*}} value %c0_ui256 selector %c4077198112_ui256 {callee_type = (!sol.string<Storage>) -> ui256, delegate_call, library_call, static_call} : !sol.address, (!sol.string<Storage>) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*attached_calldata_receiver.*}}
+// CHECK:   sol.ext_call "{{.*look.*}}"(%{{.*}}) at %{{.*}} gas %{{.*}} value %c0_ui256 selector %c1335285351_ui256 {callee_type = (!sol.string<CallData>) -> ui256, delegate_call, library_call, static_call} : !sol.address, (!sol.string<CallData>) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*attached_calldata_result.*}}
+// CHECK:   sol.ext_call "{{.*tail.*}}"(%{{.*}}) at %{{.*}} gas %{{.*}} value %c0_ui256 selector %c3126462307_ui256 {callee_type = (!sol.string<CallData>) -> !sol.string<CallData>, delegate_call, library_call, static_call} : !sol.address, (!sol.string<CallData>) -> (i1, !sol.string<Memory>)
+
+// CHECK: sol.func @{{.*attached_storage_receiver.*}}
+// CHECK:   %[[SLOT:.*]] = sol.addr_of @{{.*stored.*}} : !sol.string<Storage>
+// CHECK:   sol.ext_call "{{.*keep.*}}"(%[[SLOT]]) at %{{.*}} gas %{{.*}} value %c0_ui256 selector %c4077198112_ui256 {callee_type = (!sol.string<Storage>) -> ui256, delegate_call, library_call, static_call} : !sol.address, (!sol.string<Storage>) -> (i1, ui256)
+
+library Lib {
+    function keep(bytes storage b) external view returns (uint256) {
+        return b.length;
+    }
+
+    function look(bytes calldata b) external pure returns (uint256) {
+        return b.length;
+    }
+
+    function tail(bytes calldata b) external pure returns (bytes calldata) {
+        return b[1:];
+    }
+}
+
+contract User {
+    using Lib for bytes;
+
+    bytes stored;
+
+    function qualified_calldata_argument(bytes calldata b) public pure returns (uint256) {
+        return Lib.look(b);
+    }
+
+    function qualified_calldata_return(bytes calldata b) public pure returns (bytes memory) {
+        return Lib.tail(b);
+    }
+
+    function qualified_storage() public view returns (uint256) {
+        return Lib.keep(stored);
+    }
+
+    function attached_calldata_receiver(bytes calldata b) public pure returns (uint256) {
+        return b.look();
+    }
+
+    function attached_calldata_result(bytes calldata b) public pure returns (bytes memory) {
+        return b.tail();
+    }
+
+    function attached_storage_receiver() public view returns (uint256) {
+        return stored.keep();
+    }
+}

--- a/solx-mlir/tests/lit/library_attached.sol
+++ b/solx-mlir/tests/lit/library_attached.sol
@@ -1,0 +1,64 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// Attached internal calls: solc's print-init drops the receiver from the argument list, so this
+// is solx-only.
+
+// CHECK: sol.func @{{.*plain.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   %[[ARG:.*]] = sol.cast
+// CHECK:   sol.call @{{.*bump.*}}(%[[RECEIVER]], %[[ARG]]) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*named.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   sol.constant 4 : ui8
+// CHECK:   sol.call @{{.*bump.*}}(%[[RECEIVER]], %{{.*}}) : (ui256, ui256) -> ui256
+
+// CHECK: sol.func @{{.*storage_receiver.*}}
+// CHECK:   %[[BOX:.*]] = sol.addr_of @{{.*stored.*}} : !sol.struct<(ui256), Storage>
+// CHECK:   sol.call @{{.*fill.*}}(%[[BOX]], %{{.*}}) : (!sol.struct<(ui256), Storage>, ui256) -> ()
+
+// CHECK: sol.func @{{.*free_function.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   sol.call @{{.*double.*}}(%[[RECEIVER]]) : (ui256) -> ui256
+
+function double(uint256 a) pure returns (uint256) {
+    return a * 2;
+}
+
+library Lib {
+    struct Box {
+        uint256 value;
+    }
+
+    function bump(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+
+    function fill(Box storage box, uint256 value) internal {
+        box.value = value;
+    }
+}
+
+contract User {
+    using Lib for uint256;
+    using Lib for Lib.Box;
+    using {double} for uint256;
+
+    Lib.Box stored;
+
+    function plain(uint256 x) public pure returns (uint256) {
+        return x.bump(1);
+    }
+
+    function named(uint256 x) public pure returns (uint256) {
+        return x.bump({b: 4});
+    }
+
+    function storage_receiver(uint256 x) public {
+        stored.fill(x);
+    }
+
+    function free_function(uint256 x) public pure returns (uint256) {
+        return x.double();
+    }
+}

--- a/solx-mlir/tests/lit/library_call.sol
+++ b/solx-mlir/tests/lit/library_call.sol
@@ -1,0 +1,116 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*qualified_plain.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   sol.ext_call "{{.*mutate.*}}"(%[[ARG]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c1899731083_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call} : !sol.address, (ui256) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*qualified_static.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   sol.ext_call "{{.*observe.*}}"(%[[ARG]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c2147616019_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*qualified_try.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   %[[STATUS:[^,]*]], %{{.*}} = sol.ext_call "{{.*mutate.*}}"(%[[ARG]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c1899731083_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, try_call} : !sol.address, (ui256) -> (i1, ui256)
+// CHECK:   sol.try %[[STATUS]] {
+
+// CHECK: sol.func @{{.*qualified_static_try.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   %[[STATUS:[^,]*]], %{{.*}} = sol.ext_call "{{.*observe.*}}"(%[[ARG]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c2147616019_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call, try_call} : !sol.address, (ui256) -> (i1, ui256)
+// CHECK:   sol.try %[[STATUS]] {
+
+// CHECK: sol.func @{{.*qualified_named.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   sol.constant 2 : ui8
+// CHECK:   sol.ext_call "{{.*named.*}}"(%[[ARG]], %{{.*}}) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c3351715987_ui256 {callee_type = (ui256, ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256, ui256) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*attached_plain.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   sol.ext_call "{{.*mutate.*}}"(%[[RECEIVER]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c1899731083_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call} : !sol.address, (ui256) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*attached_static.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   sol.ext_call "{{.*observe.*}}"(%[[RECEIVER]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c2147616019_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*attached_try.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[STATUS:[^,]*]], %{{.*}} = sol.ext_call "{{.*mutate.*}}"(%[[RECEIVER]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c1899731083_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, try_call} : !sol.address, (ui256) -> (i1, ui256)
+// CHECK:   sol.try %[[STATUS]] {
+
+// CHECK: sol.func @{{.*attached_static_try.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[STATUS:[^,]*]], %{{.*}} = sol.ext_call "{{.*observe.*}}"(%[[RECEIVER]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c2147616019_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call, try_call} : !sol.address, (ui256) -> (i1, ui256)
+// CHECK:   sol.try %[[STATUS]] {
+
+// CHECK: sol.func @{{.*attached_named.*}}
+// CHECK:   %[[RECEIVER:.*]] = sol.load
+// CHECK:   sol.constant 3 : ui8
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   sol.ext_call "{{.*named.*}}"(%[[RECEIVER]], %{{.*}}) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c3351715987_ui256 {callee_type = (ui256, ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256, ui256) -> (i1, ui256)
+
+library Lib {
+    function mutate(uint256 a) external returns (uint256) {
+        return a + 1;
+    }
+
+    function named(uint256 a, uint256 b) external pure returns (uint256) {
+        return a - b;
+    }
+
+    function observe(uint256 a) external view returns (uint256) {
+        return a + 2;
+    }
+}
+
+contract User {
+    using Lib for uint256;
+
+    function qualified_plain(uint256 x) public returns (uint256) {
+        return Lib.mutate(x);
+    }
+
+    function qualified_static(uint256 x) public view returns (uint256) {
+        return Lib.observe(x);
+    }
+
+    function qualified_try(uint256 x) public returns (uint256) {
+        try Lib.mutate(x) returns (uint256 r) { return r; } catch { return 0; }
+    }
+
+    function qualified_static_try(uint256 x) public view returns (uint256) {
+        try Lib.observe(x) returns (uint256 r) { return r; } catch { return 0; }
+    }
+
+    function qualified_named(uint256 x) public pure returns (uint256) {
+        return Lib.named({b: 2, a: x});
+    }
+
+    function attached_plain(uint256 x) public returns (uint256) {
+        return x.mutate();
+    }
+
+    function attached_static(uint256 x) public view returns (uint256) {
+        return x.observe();
+    }
+
+    function attached_try(uint256 x) public returns (uint256) {
+        try x.mutate() returns (uint256 r) { return r; } catch { return 0; }
+    }
+
+    function attached_static_try(uint256 x) public view returns (uint256) {
+        try x.observe() returns (uint256 r) { return r; } catch { return 0; }
+    }
+
+    function attached_named(uint256 x) public pure returns (uint256) {
+        return x.named({b: 3});
+    }
+}

--- a/solx-mlir/tests/lit/library_call_options.sol
+++ b/solx-mlir/tests/lit/library_call_options.sol
@@ -1,0 +1,35 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// solc rejects call options on library delegatecalls ("Function call options can only be set on
+// external function calls or contract creations"); slang admits them and solx honors the named
+// gas, so this is solx-only.
+
+// CHECK: sol.func @{{.*qualified_gas.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[GAS:.*]] = sol.load
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   sol.ext_call "{{.*mutate.*}}"(%[[ARG]]) at %[[ADDR]] gas %[[GAS]] value %c0_ui256 selector %c1899731083_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256) -> (i1, ui256)
+
+// CHECK: sol.func @{{.*attached_gas.*}}
+// CHECK:   %[[GAS:.*]] = sol.load
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   sol.ext_call "{{.*mutate.*}}"(%[[ARG]]) at %[[ADDR]] gas %[[GAS]] value %c0_ui256 selector %c1899731083_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256) -> (i1, ui256)
+
+library Lib {
+    function mutate(uint256 a) external pure returns (uint256) {
+        return a + 1;
+    }
+}
+
+contract User {
+    using Lib for uint256;
+
+    function qualified_gas(uint256 x, uint256 g) public view returns (uint256) {
+        return Lib.mutate{gas: g}(x);
+    }
+
+    function attached_gas(uint256 x, uint256 g) public view returns (uint256) {
+        return x.mutate{gas: g}();
+    }
+}

--- a/solx-mlir/tests/lit/library_discarded.sol
+++ b/solx-mlir/tests/lit/library_discarded.sol
@@ -1,0 +1,40 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// A discarded library-rooted expression evaluates nothing: solc's print-init still materialises
+// the linked address for a bare library name, so this is solx-only.
+
+// CHECK: sol.contract @{{.*C.*}} {
+// CHECK: sol.func @{{.*discarded_function.*}}()
+// CHECK-NEXT:   sol.return
+// CHECK: sol.func @{{.*discarded_library.*}}()
+// CHECK-NEXT:   sol.return
+// CHECK: sol.func @{{.*discarded_member.*}}()
+// CHECK-NEXT:   sol.return
+// CHECK: } {kind = #Contract}
+
+// CHECK: sol.contract @{{.*Library.*}} {
+// CHECK: sol.func @{{.*SEEN.*}}() -> ui256 attributes {orig_fn_type = () -> ui256, selector = -764320198 : i32, state_mutability = #Pure}
+// CHECK:   sol.constant 9 : ui8
+// CHECK: } {kind = #Library}
+
+contract C {
+    function discarded_function() public pure {
+        Library.identity;
+    }
+
+    function discarded_library() public pure {
+        Library;
+    }
+
+    function discarded_member() public pure {
+        Library.SEEN;
+    }
+}
+
+library Library {
+    uint256 public constant SEEN = 9;
+
+    function identity(uint256 a) internal pure returns (uint256) {
+        return a;
+    }
+}

--- a/solx-mlir/tests/lit/library_internal.sol
+++ b/solx-mlir/tests/lit/library_internal.sol
@@ -1,0 +1,53 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// Copies land at their first reference, after the own functions; solc's print-init emits them
+// first, so this is solx-only.
+
+// CHECK: sol.contract @{{.*Lib.*}} {
+// CHECK: sol.func @{{.*chain.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #NonPayable}
+// CHECK:   sol.call @{{.*link.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*link.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #NonPayable}
+// CHECK:   sol.revert "Overrun(uint256)" %{{.*}} : ui256 {call}
+// CHECK:   sol.emit "Consumed(uint256)" indexed = [%{{.*}}] : ui256
+// CHECK:   sol.malloc : !sol.struct<(ui256, ui256), Memory>
+// CHECK: } {kind = #Library}
+
+// CHECK: sol.contract @{{.*User.*}} {
+// CHECK: sol.func @{{.*consume.*}}
+// CHECK:   sol.call @{{.*chain.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*chain.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #NonPayable}
+// CHECK:   sol.call @{{.*link.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*link.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #NonPayable}
+// CHECK:   sol.revert "Overrun(uint256)" %{{.*}} : ui256 {call}
+// CHECK:   sol.emit "Consumed(uint256)" indexed = [%{{.*}}] : ui256
+// CHECK: } {kind = #Contract}
+
+library Lib {
+    enum Kind { Zero, One }
+
+    error Overrun(uint256 x);
+
+    event Consumed(uint256 indexed x);
+
+    struct Pair {
+        uint256 x;
+        uint256 y;
+    }
+
+    function chain(uint256 a) internal returns (uint256) {
+        return link(a) + 1;
+    }
+
+    function link(uint256 a) internal returns (uint256) {
+        if (a == 0) revert Overrun(a);
+        emit Consumed(a);
+        Pair memory pair = Pair(a, uint256(Kind.One));
+        return pair.x + pair.y;
+    }
+}
+
+contract User {
+    function consume(uint256 x) public returns (uint256) {
+        return Lib.chain(x);
+    }
+}

--- a/solx-mlir/tests/lit/library_module_alias.sol
+++ b/solx-mlir/tests/lit/library_module_alias.sol
@@ -1,0 +1,31 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// A library qualified through a module alias: solc's print-init substitutes `sol.timestamp` for
+// the address, so this is solx-only.
+
+// CHECK: sol.func @{{.*alias_address.*}}() -> !sol.address
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   sol.return %[[ADDR]] : !sol.address
+
+// CHECK: sol.func @{{.*alias_call.*}}
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   %[[ARG:.*]] = sol.load
+// CHECK:   sol.ext_call "{{.*visible.*}}"(%[[ARG]]) at %[[ADDR]] gas %{{.*}} value %c0_ui256 selector %c2825669559_ui256 {callee_type = (ui256) -> ui256, delegate_call, library_call, static_call} : !sol.address, (ui256) -> (i1, ui256)
+
+import "./library_module_alias.sol" as M;
+
+library Lib {
+    function visible(uint256 a) external pure returns (uint256) {
+        return a;
+    }
+}
+
+contract User {
+    function alias_address() public pure returns (address) {
+        return address(M.Lib);
+    }
+
+    function alias_call(uint256 x) public pure returns (uint256) {
+        return M.Lib.visible(x);
+    }
+}

--- a/solx-mlir/tests/lit/library_object.sol
+++ b/solx-mlir/tests/lit/library_object.sol
@@ -1,0 +1,25 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.contract @{{.*Lib.*}} {
+// CHECK: sol.func @{{.*external_member.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, orig_fn_type = (ui256) -> ui256, selector = -1958955763 : i32, state_mutability = #Pure}
+// CHECK:   sol.call @{{.*inner.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*inner.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #Pure}
+// CHECK:   sol.call @{{.*shared.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: } {kind = #Library}
+
+function shared(uint256 a) pure returns (uint256) {
+    return a + 1;
+}
+
+library Lib {
+    uint256 internal constant FACTOR = 2;
+
+    function external_member(uint256 a) external pure returns (uint256) {
+        return inner(a);
+    }
+
+    function inner(uint256 a) internal pure returns (uint256) {
+        return shared(a) * FACTOR;
+    }
+}

--- a/solx-mlir/tests/lit/library_reachable.sol
+++ b/solx-mlir/tests/lit/library_reachable.sol
@@ -1,0 +1,63 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// Copies inside the consumer module: solc's print-init drops the consumer module when a bare
+// public sibling is reached, so this is solx-only.
+
+// CHECK: sol.contract @{{.*User.*}} {
+// CHECK: sol.func @{{.*}} attributes {{.*}}kind = #Constructor
+// CHECK:   sol.call @{{.*seed.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*seed.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #Pure}
+// CHECK:   sol.call @{{.*step.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*consume.*}}
+// CHECK:   sol.call @{{.*calls_public_sibling.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*calls_public_sibling.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #Pure}
+// CHECK:   sol.call @{{.*public_sibling.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*public_sibling.*}}(%{{.*}}: ui256) -> ui256 attributes {id = {{[0-9]+}} : i64, state_mutability = #Pure}
+// CHECK:   sol.call @{{.*bare.*}}(%{{.*}}) : (ui256) -> ui256
+// CHECK: sol.func @{{.*total.*}}
+// CHECK:   sol.call @"operator_add({{[^"]*}}"
+// CHECK: sol.func @"operator_add({{[^"]*}}"
+// CHECK: sol.func @{{.*planted.*}}()
+// CHECK: } {kind = #Contract}
+
+type Score is uint256;
+
+using {operator_add as +} for Score global;
+
+function operator_add(Score a, Score b) pure returns (Score) {
+    return Score.wrap(Score.unwrap(a) + Score.unwrap(b));
+}
+
+library Lib {
+    function bare(uint256 a) internal pure returns (uint256) {
+        return a * 3;
+    }
+
+    function calls_public_sibling(uint256 a) internal pure returns (uint256) {
+        return public_sibling(a);
+    }
+
+    function public_sibling(uint256 a) public pure returns (uint256) {
+        return bare(a);
+    }
+
+    function seed(uint256 a) internal pure returns (uint256) {
+        return step(a);
+    }
+
+    function step(uint256 a) internal pure returns (uint256) {
+        return a + 1;
+    }
+}
+
+contract User {
+    uint256 public planted = Lib.seed(21);
+
+    function consume(uint256 x) public pure returns (uint256) {
+        return Lib.calls_public_sibling(x);
+    }
+
+    function total(Score x) public pure returns (Score) {
+        return operator_add(x, x) + x;
+    }
+}

--- a/solx-mlir/tests/lit/library_selector.sol
+++ b/solx-mlir/tests/lit/library_selector.sol
@@ -1,0 +1,47 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*fold.*}}(%{{.*}}: !sol.struct<(ui256, ui256), Memory>) -> ui256 attributes {id = {{[0-9]+}} : i64, orig_fn_type = (!sol.struct<(ui256, ui256), Memory>) -> ui256, selector = -699220919 : i32, state_mutability = #Pure}
+
+// CHECK: sol.func @{{.*grow.*}}(%{{.*}}: !sol.array<? x ui256, Storage>) -> ui256 attributes {id = {{[0-9]+}} : i64, orig_fn_type = (!sol.array<? x ui256, Storage>) -> ui256, selector = 1149502785 : i32, state_mutability = #NonPayable}
+// CHECK:   sol.push %{{.*}} : !sol.array<? x ui256, Storage> -> !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func @{{.*error_selector.*}}
+// CHECK:   sol.constant 219656568 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+
+// CHECK: sol.func @{{.*function_selector.*}}
+// CHECK:   sol.constant 2825669559 : ui32
+// CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
+
+library Lib {
+    struct Pair {
+        uint256 x;
+        uint256 y;
+    }
+
+    error Halt(uint256 x);
+
+    function fold(Pair memory pair) external pure returns (uint256) {
+        return pair.x + pair.y;
+    }
+
+    function grow(uint256[] storage a) external returns (uint256) {
+        a.push(1);
+        return a.length;
+    }
+
+    function visible(uint256 a) external pure returns (uint256) {
+        return a;
+    }
+}
+
+contract User {
+    function error_selector() external pure returns (bytes4) {
+        return Lib.Halt.selector;
+    }
+
+    function function_selector() external pure returns (bytes4) {
+        return Lib.visible.selector;
+    }
+}

--- a/solx-mlir/tests/lit/library_value.sol
+++ b/solx-mlir/tests/lit/library_value.sol
@@ -1,0 +1,14 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*library_address.*}}() -> !sol.address
+// CHECK:   %[[ADDR:.*]] = sol.lib_addr "{{[^"]*}}Lib" : !sol.address
+// CHECK:   sol.return %[[ADDR]] : !sol.address
+
+library Lib {}
+
+contract User {
+    function library_address() public pure returns (address) {
+        return address(Lib);
+    }
+}

--- a/solx-mlir/tests/lit/namespace_function_pointer.sol
+++ b/solx-mlir/tests/lit/namespace_function_pointer.sol
@@ -4,11 +4,21 @@
 // function pointer, like a bare g: solc's print-init crashes (SIGSEGV), so this
 // is solx-only.
 
+// CHECK: sol.contract @{{.*C.*}} {
 // CHECK: sol.func @{{.*g.*}}() -> ui256 attributes {{.*}}id = {{[0-9]+}}
-
 // CHECK: sol.func @{{.*run.*}}
-// CHECK: sol.func_constant @{{.*g.*}} : !sol.func_ref<() -> ui256>
-// CHECK: sol.icall %{{[0-9]+}}() : !sol.func_ref<() -> ui256>, () -> ui256
+// CHECK:   sol.func_constant @{{.*g.*}} : !sol.func_ref<() -> ui256>
+// CHECK:   sol.icall %{{[0-9]+}}() : !sol.func_ref<() -> ui256>, () -> ui256
+// CHECK: sol.func @{{.*qualified_library.*}}
+// CHECK:   sol.func_constant @{{.*pick.*}} : !sol.func_ref<() -> ui256>
+// CHECK:   sol.icall %{{[0-9]+}}() : !sol.func_ref<() -> ui256>, () -> ui256
+// CHECK: } {kind = #Contract}
+
+// CHECK: sol.contract @{{.*Lib.*}} {
+// CHECK: sol.func @{{.*taker.*}}
+// CHECK:   sol.func_constant @{{.*pick.*}} : !sol.func_ref<() -> ui256>
+// CHECK:   sol.icall %{{[0-9]+}}() : !sol.func_ref<() -> ui256>, () -> ui256
+// CHECK: } {kind = #Library}
 
 contract C {
     function g() internal returns (uint256) {
@@ -17,6 +27,22 @@ contract C {
 
     function run() public returns (uint256) {
         function () internal returns (uint256) functionPointer = C.g;
+        return functionPointer();
+    }
+
+    function qualified_library() public pure returns (uint256) {
+        function () internal pure returns (uint256) functionPointer = Lib.pick;
+        return functionPointer();
+    }
+}
+
+library Lib {
+    function pick() internal pure returns (uint256) {
+        return 5;
+    }
+
+    function taker() internal pure returns (uint256) {
+        function () internal pure returns (uint256) functionPointer = Lib.pick;
         return functionPointer();
     }
 }

--- a/solx-mlir/tests/lit/type_meta.sol
+++ b/solx-mlir/tests/lit/type_meta.sol
@@ -1,28 +1,37 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
 // RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
 
-// CHECK: sol.func @{{.*ccode.*}}() -> !sol.string<Memory>
-// CHECK:   sol.object_code "{{[^"]*}}Other{{[^"]*}}" : !sol.string<Memory>
+// CHECK: sol.func @{{.*contract_creation_code.*}}() -> !sol.string<Memory>
+// CHECK:   sol.object_code "{{[^"]*}}Other{{[0-9_]*}}" : !sol.string<Memory>
 
-// CHECK: sol.func @{{.*iid.*}}() -> !sol.fixedbytes<4>
-// CHECK:   sol.constant 3506811462 : ui32
-
-// CHECK: sol.func @{{.*iname.*}}() -> !sol.string<Memory>
-// CHECK:   sol.string_lit "IFoo" -> !sol.string<Memory>
-
-// CHECK: sol.func @{{.*nm.*}}() -> !sol.string<Memory>
+// CHECK: sol.func @{{.*contract_name.*}}() -> !sol.string<Memory>
 // CHECK:   sol.string_lit "Other" -> !sol.string<Memory>
 
-// CHECK: sol.func @{{.*rcode.*}}() -> !sol.string<Memory>
-// CHECK:   sol.object_code "{{[^"]*}}Other{{[^"]*}}_deployed" : !sol.string<Memory>
+// CHECK: sol.func @{{.*contract_runtime_code.*}}() -> !sol.string<Memory>
+// CHECK:   sol.object_code "{{[^"]*}}Other{{[0-9_]*}}_deployed" : !sol.string<Memory>
 
-// CHECK: sol.func @{{.*tmax.*}}() -> ui16
+// CHECK: sol.func @{{.*integer_max.*}}() -> ui16
 // CHECK:   sol.constant 65535 : ui16
 
-// CHECK: sol.func @{{.*tmin.*}}() -> si8
+// CHECK: sol.func @{{.*integer_min.*}}() -> si8
 // CHECK:   sol.constant -128 : si8
 
-// CHECK: sol.func @{{.*id.*}}() -> !sol.fixedbytes<4>
+// CHECK: sol.func @{{.*interface_id.*}}() -> !sol.fixedbytes<4>
+// CHECK:   sol.constant 3506811462 : ui32
+
+// CHECK: sol.func @{{.*interface_name.*}}() -> !sol.string<Memory>
+// CHECK:   sol.string_lit "IFoo" -> !sol.string<Memory>
+
+// CHECK: sol.func @{{.*library_creation_code.*}}() -> !sol.string<Memory>
+// CHECK:   sol.object_code "{{[^"]*}}Registry{{[0-9_]*}}" : !sol.string<Memory>
+
+// CHECK: sol.func @{{.*library_name.*}}() -> !sol.string<Memory>
+// CHECK:   sol.string_lit "Registry" -> !sol.string<Memory>
+
+// CHECK: sol.func @{{.*library_runtime_code.*}}() -> !sol.string<Memory>
+// CHECK:   sol.object_code "{{[^"]*}}Registry{{[0-9_]*}}_deployed" : !sol.string<Memory>
+
+// CHECK: sol.func @{{.*interface_id_over_non_functions.*}}() -> !sol.fixedbytes<4>
 // CHECK:   sol.constant 1547088262 : ui32
 // CHECK:   sol.bytes_cast %{{.*}} : ui32 to !sol.fixedbytes<4>
 // CHECK:   sol.return
@@ -38,19 +47,45 @@ contract Other {
 }
 
 contract Meta {
-    function ccode() public pure returns (bytes memory) { return type(Other).creationCode; }
+    function contract_creation_code() public pure returns (bytes memory) {
+        return type(Other).creationCode;
+    }
 
-    function iid() public pure returns (bytes4) { return type(IFoo).interfaceId; }
+    function contract_name() public pure returns (string memory) {
+        return type(Other).name;
+    }
 
-    function iname() public pure returns (string memory) { return type(IFoo).name; }
+    function contract_runtime_code() public pure returns (bytes memory) {
+        return type(Other).runtimeCode;
+    }
 
-    function nm() public pure returns (string memory) { return type(Other).name; }
+    function integer_max() public pure returns (uint16) {
+        return type(uint16).max;
+    }
 
-    function rcode() public pure returns (bytes memory) { return type(Other).runtimeCode; }
+    function integer_min() public pure returns (int8) {
+        return type(int8).min;
+    }
 
-    function tmax() public pure returns (uint16) { return type(uint16).max; }
+    function interface_id() public pure returns (bytes4) {
+        return type(IFoo).interfaceId;
+    }
 
-    function tmin() public pure returns (int8) { return type(int8).min; }
+    function interface_name() public pure returns (string memory) {
+        return type(IFoo).name;
+    }
+
+    function library_creation_code() public pure returns (bytes memory) {
+        return type(Registry).creationCode;
+    }
+
+    function library_name() public pure returns (string memory) {
+        return type(Registry).name;
+    }
+
+    function library_runtime_code() public pure returns (bytes memory) {
+        return type(Registry).runtimeCode;
+    }
 }
 
 interface I {
@@ -62,7 +97,9 @@ interface I {
 }
 
 contract NonFunctionMembers {
-    function id() public pure returns (bytes4) {
+    function interface_id_over_non_functions() public pure returns (bytes4) {
         return type(I).interfaceId;
     }
 }
+
+library Registry {}

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-itertools.workspace = true
 num.workspace = true
 num-traits = "0.2"
 ruint.workspace = true
@@ -20,7 +19,6 @@ semver.workspace = true
 
 slang_solidity_v2.workspace = true
 
-solx-codegen-evm = { path = "../solx-codegen-evm" }
 solx-core = { path = "../solx-core", features = ["mlir"] }
 solx-mlir = { path = "../solx-mlir" }
 solx-standard-json = { path = "../solx-standard-json", features = ["mlir"] }

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -30,6 +30,7 @@ use solx_utils::FunctionReferenceKind;
 
 use crate::contract::function::expression::call::external_callee::ExternalCallee;
 use crate::contract::function::expression::call::options::Options;
+use crate::contract::object::Object;
 use crate::scope::function::FunctionScope;
 use crate::scope::source_unit::SourceUnitScope;
 
@@ -52,12 +53,21 @@ pub enum Call {
     /// which is where an overload is disambiguated and a decorated callee carries its partial
     /// application.
     External(MemberAccessExpression, ExternalCallee, FunctionType),
+    /// A qualified call to an externally visible library function (`L.f(x)`), dispatched by
+    /// `DELEGATECALL` at the linked library address on the library selector.
+    Library(FunctionDefinition, u32),
+    /// An attached call to an externally visible library function (`x.f(y)`): the receiver leads
+    /// the argument list of the same library dispatch.
+    AttachedLibrary(Expression, FunctionDefinition, u32),
     /// A member-access callee (`address.send`, `abi.encode`, `abi.decode`). The member is resolved
     /// at emission, so a member resolving to no built-in or to one not lowered yet is rejected in
     /// one place rather than at both classification and emission.
     Member(MemberAccessExpression),
     /// A direct call to a named function.
     Function(FunctionDefinition),
+    /// An attached call to a selectorless library or free function: the receiver leads the
+    /// argument list of an internal `sol.call`.
+    Attached(Expression, FunctionDefinition),
     /// A call through a function-typed value, internal or external.
     FunctionPointer(Expression, FunctionType),
 }
@@ -105,10 +115,31 @@ impl Call {
                 );
                 values
             }
+            Self::Library(function_definition, selector) => {
+                let (_status, values) =
+                    Self::library(&function_definition, selector, &arguments, false, scope);
+                values
+            }
+            Self::AttachedLibrary(receiver, function_definition, selector) => {
+                let (_status, values) = Self::attached_library(
+                    receiver,
+                    &function_definition,
+                    selector,
+                    &arguments,
+                    false,
+                    scope,
+                );
+                values
+            }
             Self::Member(access) => {
                 Self::member(&access, node, &arguments, options.as_ref(), scope)
             }
             Self::Function(function_definition) => scope.call(&function_definition, &arguments),
+            Self::Attached(receiver, function_definition) => {
+                let operands: Vec<Expression> =
+                    std::iter::once(receiver).chain(arguments).collect();
+                scope.call(&function_definition, &operands)
+            }
             Self::FunctionPointer(callee, function_type) => {
                 Self::function_pointer(&callee, &function_type, &arguments, options.as_ref(), scope)
             }
@@ -153,6 +184,19 @@ impl Call {
                 true,
                 scope,
             ),
+            Self::Library(function_definition, selector) => {
+                Self::library(&function_definition, selector, &arguments, true, scope)
+            }
+            Self::AttachedLibrary(receiver, function_definition, selector) => {
+                Self::attached_library(
+                    receiver,
+                    &function_definition,
+                    selector,
+                    &arguments,
+                    true,
+                    scope,
+                )
+            }
             Self::FunctionPointer(callee, function_type) => Self::external_pointer(
                 &callee,
                 &function_type,
@@ -168,7 +212,8 @@ impl Call {
             | Self::Allocation
             | Self::TypeConversion
             | Self::Builtin(_)
-            | Self::Function(_) => {
+            | Self::Function(_)
+            | Self::Attached(..) => {
                 unreachable!("a guarded call dispatches externally or creates a contract")
             }
         }
@@ -230,23 +275,47 @@ impl Call {
                         function_type,
                     );
                 }
-                if let Expression::Identifier(namespace) = access.operand() {
-                    match namespace.resolve_to_definition() {
-                        Some(Definition::Contract(_)) => {
-                            if let Some(Definition::Function(function_definition)) =
-                                access.member().resolve_to_definition()
-                            {
-                                return Self::Function(function_definition);
-                            }
-                            if let Some(Type::Function(function_type)) = access.get_type() {
-                                return Self::FunctionPointer(
-                                    Expression::MemberAccessExpression(access),
-                                    function_type,
-                                );
-                            }
+                if matches!(
+                    FunctionScope::resolved_definition(&access.operand()),
+                    Some(Definition::Contract(_) | Definition::Import(_))
+                ) {
+                    if let Some(Definition::Function(function_definition)) =
+                        access.member().resolve_to_definition()
+                    {
+                        return Self::Function(function_definition);
+                    }
+                    if let Some(Type::Function(function_type)) = access.get_type() {
+                        return Self::FunctionPointer(
+                            Expression::MemberAccessExpression(access),
+                            function_type,
+                        );
+                    }
+                }
+                if let Some(Definition::Function(function_definition)) =
+                    access.member().resolve_to_definition()
+                {
+                    match (
+                        FunctionScope::resolved_definition(&access.operand()),
+                        function_definition.enclosing_definition(),
+                    ) {
+                        (Some(Definition::Library(_)), _) => {
+                            return match function_definition.compute_selector() {
+                                Some(selector) => Self::Library(function_definition, selector),
+                                None => Self::Function(function_definition),
+                            };
                         }
-                        Some(Definition::Library(_)) => {
-                            unimplemented!("unsupported library call: {}", access.member().name())
+                        (_, Some(Definition::Library(_))) => {
+                            return match function_definition.compute_selector() {
+                                Some(selector) => Self::AttachedLibrary(
+                                    access.operand(),
+                                    function_definition,
+                                    selector,
+                                ),
+                                None => Self::Attached(access.operand(), function_definition),
+                            };
+                        }
+                        (_, None) => {
+                            return Self::Attached(access.operand(), function_definition);
                         }
                         _ => {}
                     }
@@ -314,13 +383,25 @@ impl Call {
                 ),
                 Self::Creation(_, Some(function_definition))
                 | Self::External(_, ExternalCallee::Function(function_definition, _), _)
-                | Self::Function(function_definition) => FunctionScope::named_arguments(
+                | Self::Function(function_definition)
+                | Self::Library(function_definition, _) => FunctionScope::named_arguments(
                     &named,
                     function_definition
                         .parameters()
                         .iter()
                         .map(|parameter| parameter.node_id()),
                 ),
+                Self::Attached(_, function_definition)
+                | Self::AttachedLibrary(_, function_definition, _) => {
+                    FunctionScope::named_arguments(
+                        &named,
+                        function_definition
+                            .parameters()
+                            .iter()
+                            .skip(1)
+                            .map(|parameter| parameter.node_id()),
+                    )
+                }
                 Self::FunctionPointer(_, function_type) => {
                     match function_type.associated_definition() {
                         Some(Definition::Function(function_definition)) => {
@@ -400,9 +481,7 @@ impl Call {
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Value<'context> {
         let result_type = scope.typing(call.get_type());
-        let options = options
-            .map(|options| Options::new(options, scope))
-            .unwrap_or_default();
+        let options = Options::new(options, scope);
         let parameter_types: Vec<MlirType<'context>> = constructor
             .map(|constructor| {
                 constructor
@@ -414,10 +493,7 @@ impl Call {
             .unwrap_or_default();
         let converted = scope.external_arguments(arguments, &parameter_types);
         let amount = options.amount(scope);
-        let object = SourceUnitScope::object_identifier(
-            contract_definition.get_file_id(),
-            contract_definition.name().name(),
-        );
+        let object = Object::Contract(contract_definition.clone()).identifier();
         let create = if guarded {
             Value::create_contract_try
         } else {
@@ -558,26 +634,18 @@ impl Call {
                 None
             }
             BuiltIn::Gasleft => Some(Value::gas_left(scope)),
-            BuiltIn::Keccak256 => {
+            BuiltIn::Keccak256 | BuiltIn::Sha256 | BuiltIn::Ripemd160 => {
+                let hash = match built_in {
+                    BuiltIn::Keccak256 => Value::keccak256,
+                    BuiltIn::Sha256 => Value::sha256,
+                    BuiltIn::Ripemd160 => Value::ripemd160,
+                    _ => unreachable!("the arm admits the three hash built-ins"),
+                };
                 let data = scope.converted(
                     &arguments[0],
                     MlirType::string(scope.melior, solx_utils::DataLocation::Memory),
                 );
-                Some(Value::keccak256(data, scope))
-            }
-            BuiltIn::Sha256 => {
-                let data = scope.converted(
-                    &arguments[0],
-                    MlirType::string(scope.melior, solx_utils::DataLocation::Memory),
-                );
-                Some(Value::sha256(data, scope))
-            }
-            BuiltIn::Ripemd160 => {
-                let data = scope.converted(
-                    &arguments[0],
-                    MlirType::string(scope.melior, solx_utils::DataLocation::Memory),
-                );
-                Some(Value::ripemd160(data, scope))
+                Some(hash(data, scope))
             }
             BuiltIn::Ecrecover => {
                 let values = scope.positional_arguments(arguments);
@@ -619,22 +687,149 @@ impl Call {
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let address = scope.converted(&access.operand(), MlirType::address(scope.melior, false));
-        let options = options
-            .map(|options| Options::new(options, scope))
-            .unwrap_or_default();
+        let options = Options::new(options, scope);
         let function = callee.function(function_type, scope.contract.source_unit);
         let converted = scope.external_arguments(arguments, &function.function_type.parameters);
-        let selector = Value::selector(callee.selector(), MlirType::field(scope.melior), scope);
+        let is_static = StateMutability::from(function_type.mutability()).is_static();
+        Self::external_dispatch(
+            &function,
+            &converted,
+            &function.function_type.results,
+            address,
+            callee.selector(),
+            &options,
+            false,
+            is_static,
+            guarded,
+            scope,
+        )
+    }
+
+    /// Dispatches a qualified library call (`L.f(x)`) by `DELEGATECALL` at the linked library
+    /// address on the library selector: the address precedes the arguments, and the externalized
+    /// signature types both the callee and the results.
+    fn library<'context>(
+        definition: &FunctionDefinition,
+        selector: u32,
+        arguments: &[Expression],
+        guarded: bool,
+        scope: &mut FunctionScope<'_, '_, 'context>,
+    ) -> (Value<'context>, Vec<Value<'context>>) {
+        let address = Self::library_address(definition, scope);
+        let Some(Type::Function(externalized_type)) = definition.externalized_type() else {
+            unreachable!("slang externalizes every selector-bearing function's type");
+        };
+        let function = Function::new(
+            SourceUnitScope::function_symbol(definition),
+            scope.contract.source_unit.function_type(&externalized_type),
+        );
+        let converted = scope.external_arguments(arguments, &function.function_type.parameters);
+        let is_static = StateMutability::from(definition.attributes().mutability()).is_static();
+        Self::external_dispatch(
+            &function,
+            &converted,
+            &function.function_type.results,
+            address,
+            selector,
+            &Options::default(),
+            true,
+            is_static,
+            guarded,
+            scope,
+        )
+    }
+
+    /// Dispatches an attached library call (`x.f(y)`): the receiver leads the argument list and
+    /// the address follows it, the declared signature types the callee, and the externalized one
+    /// the results.
+    fn attached_library<'context>(
+        receiver: Expression,
+        definition: &FunctionDefinition,
+        selector: u32,
+        arguments: &[Expression],
+        guarded: bool,
+        scope: &mut FunctionScope<'_, '_, 'context>,
+    ) -> (Value<'context>, Vec<Value<'context>>) {
+        let function = scope.contract.source_unit.function_signature(definition);
+        let mut converted = scope.external_arguments(
+            std::slice::from_ref(&receiver),
+            &function.function_type.parameters[..1],
+        );
+        converted
+            .extend(scope.external_arguments(arguments, &function.function_type.parameters[1..]));
+        let address = Self::library_address(definition, scope);
+        let Some(Type::Function(externalized_type)) = definition.externalized_type() else {
+            unreachable!("slang externalizes every selector-bearing function's type");
+        };
+        let result_types = scope
+            .contract
+            .source_unit
+            .function_type(&externalized_type)
+            .results;
+        let is_static = StateMutability::from(definition.attributes().mutability()).is_static();
+        Self::external_dispatch(
+            &function,
+            &converted,
+            &result_types,
+            address,
+            selector,
+            &Options::default(),
+            true,
+            is_static,
+            guarded,
+            scope,
+        )
+    }
+
+    /// The linked address of the library enclosing `definition` (`sol.lib_addr`).
+    fn library_address<'context>(
+        definition: &FunctionDefinition,
+        scope: &mut FunctionScope<'_, '_, 'context>,
+    ) -> Value<'context> {
+        let Some(Definition::Library(library)) = definition.enclosing_definition() else {
+            unreachable!("a library callee is enclosed by its library");
+        };
+        Value::library_address(Object::Library(library).identifier().as_str(), scope)
+    }
+
+    /// Emits the `sol.ext_call` an external dispatch selects: the `library_*` emitters carry
+    /// `delegate_call, library_call`, while `static_call` and the `try` wrapper are independent
+    /// axes.
+    fn external_dispatch<'context>(
+        function: &Function<'context>,
+        arguments: &[Value<'context>],
+        result_types: &[MlirType<'context>],
+        address: Value<'context>,
+        selector: u32,
+        options: &Options<'context>,
+        is_library: bool,
+        is_static: bool,
+        guarded: bool,
+        scope: &mut FunctionScope<'_, '_, 'context>,
+    ) -> (Value<'context>, Vec<Value<'context>>) {
+        let selector = Value::selector(selector, MlirType::field(scope.melior), scope);
         let gas = options.gas(scope);
         let amount = options.amount(scope);
-        let is_static = StateMutability::from(function_type.mutability()).is_static();
-        let call = match (is_static, guarded) {
-            (false, false) => Function::external_call,
-            (true, false) => Function::external_static_call,
-            (false, true) => Function::external_try_call,
-            (true, true) => Function::external_static_try_call,
+        let call = match (is_library, is_static, guarded) {
+            (false, false, false) => Function::external_call,
+            (false, true, false) => Function::external_static_call,
+            (false, false, true) => Function::external_try_call,
+            (false, true, true) => Function::external_static_try_call,
+            (true, false, false) => Function::library_call,
+            (true, true, false) => Function::library_static_call,
+            (true, false, true) => Function::library_try_call,
+            (true, true, true) => Function::library_static_try_call,
         };
-        call(&function, &converted, address, selector, gas, amount, scope)
+        call(
+            function,
+            arguments,
+            result_types,
+            address,
+            selector,
+            gas,
+            amount,
+            scope,
+        )
     }
 
     /// Resolves the member to its built-in and lowers it. `abi.decode` takes its result type from
@@ -649,45 +844,31 @@ impl Call {
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Vec<Value<'context>> {
         match access.member().resolve_to_built_in() {
-            Some(BuiltIn::AddressCall) => {
+            Some(
+                built_in @ (BuiltIn::AddressCall
+                | BuiltIn::AddressDelegatecall
+                | BuiltIn::AddressStaticcall),
+            ) => {
                 let address =
                     scope.converted(&access.operand(), MlirType::address(scope.melior, false));
-                let options = options
-                    .map(|options| Options::new(options, scope))
-                    .unwrap_or_default();
+                let options = Options::new(options, scope);
                 let input = scope.converted(
                     &arguments[0],
                     MlirType::string(scope.melior, solx_utils::DataLocation::Memory),
                 );
                 let gas = options.gas(scope);
-                let amount = options.amount(scope);
-                Value::bare_call(address, gas, amount, input, scope)
-            }
-            Some(BuiltIn::AddressDelegatecall) => {
-                let address =
-                    scope.converted(&access.operand(), MlirType::address(scope.melior, false));
-                let options = options
-                    .map(|options| Options::new(options, scope))
-                    .unwrap_or_default();
-                let input = scope.converted(
-                    &arguments[0],
-                    MlirType::string(scope.melior, solx_utils::DataLocation::Memory),
-                );
-                let gas = options.gas(scope);
-                Value::bare_delegate_call(address, gas, input, scope)
-            }
-            Some(BuiltIn::AddressStaticcall) => {
-                let address =
-                    scope.converted(&access.operand(), MlirType::address(scope.melior, false));
-                let options = options
-                    .map(|options| Options::new(options, scope))
-                    .unwrap_or_default();
-                let input = scope.converted(
-                    &arguments[0],
-                    MlirType::string(scope.melior, solx_utils::DataLocation::Memory),
-                );
-                let gas = options.gas(scope);
-                Value::bare_static_call(address, gas, input, scope)
+                match built_in {
+                    BuiltIn::AddressCall => {
+                        Value::bare_call(address, gas, options.amount(scope), input, scope)
+                    }
+                    BuiltIn::AddressDelegatecall => {
+                        Value::bare_delegate_call(address, gas, input, scope)
+                    }
+                    BuiltIn::AddressStaticcall => {
+                        Value::bare_static_call(address, gas, input, scope)
+                    }
+                    _ => unreachable!("the arm admits the three bare-call built-ins"),
+                }
             }
             Some(BuiltIn::AddressSend) => {
                 let address =
@@ -820,7 +1001,7 @@ impl Call {
                 Value::decode(payload, &result_types, scope)
             }
             Some(BuiltIn::ArrayPop) => {
-                scope.expression_place(&access.operand()).0.pop(scope);
+                Place::from(scope.expression(&access.operand())).pop(scope);
                 Vec::new()
             }
             Some(BuiltIn::ArrayPush) => {
@@ -829,7 +1010,7 @@ impl Call {
                     .get_type()
                     .expect("base of array push has a resolved type");
                 let value_argument = arguments.first();
-                let (place, _) = scope.expression_place(&base);
+                let place = Place::from(scope.expression(&base));
 
                 if let Type::Bytes(_) = &base_slang_type
                     && let Some(value_argument) = value_argument
@@ -943,9 +1124,7 @@ impl Call {
             results,
         } = scope.contract.source_unit.function_type(function_type);
         let pointer = scope.expression(callee);
-        let options = options
-            .map(|options| Options::new(options, scope))
-            .unwrap_or_default();
+        let options = Options::new(options, scope);
         let converted = scope.external_arguments(arguments, &parameters);
         let gas = options.gas(scope);
         let amount = options.amount(scope);
@@ -993,17 +1172,18 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             .expect("a user-defined operator's function returns one value")
     }
 
-    /// Resolves the callee's pre-registered MLIR signature by node id and converts each argument to
-    /// its declared parameter type before `sol.call`.
+    /// Defines the callee in this module if absent and converts each argument to its declared
+    /// parameter type before `sol.call`.
     fn call(
         &mut self,
         function_definition: &FunctionDefinition,
         arguments: &[Expression],
     ) -> Vec<Value<'context>> {
+        self.contract.function_definition(function_definition);
         let signature = self
             .contract
             .source_unit
-            .function_signature(function_definition.node_id());
+            .function_signature(function_definition);
         let converted = self.converted_arguments(arguments, &signature.function_type.parameters);
         Function::call(&signature, &converted, self)
     }

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -116,8 +116,14 @@ impl Call {
                 values
             }
             Self::Library(function_definition, selector) => {
-                let (_status, values) =
-                    Self::library(&function_definition, selector, &arguments, false, scope);
+                let (_status, values) = Self::library(
+                    &function_definition,
+                    selector,
+                    &arguments,
+                    options.as_ref(),
+                    false,
+                    scope,
+                );
                 values
             }
             Self::AttachedLibrary(receiver, function_definition, selector) => {
@@ -126,6 +132,7 @@ impl Call {
                     &function_definition,
                     selector,
                     &arguments,
+                    options.as_ref(),
                     false,
                     scope,
                 );
@@ -184,15 +191,21 @@ impl Call {
                 true,
                 scope,
             ),
-            Self::Library(function_definition, selector) => {
-                Self::library(&function_definition, selector, &arguments, true, scope)
-            }
+            Self::Library(function_definition, selector) => Self::library(
+                &function_definition,
+                selector,
+                &arguments,
+                options.as_ref(),
+                true,
+                scope,
+            ),
             Self::AttachedLibrary(receiver, function_definition, selector) => {
                 Self::attached_library(
                     receiver,
                     &function_definition,
                     selector,
                     &arguments,
+                    options.as_ref(),
                     true,
                     scope,
                 )
@@ -712,10 +725,12 @@ impl Call {
         definition: &FunctionDefinition,
         selector: u32,
         arguments: &[Expression],
+        options: Option<&CallOptions>,
         is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let address = Self::library_address(definition, scope);
+        let options = Options::new(options, scope);
         let Some(Type::Function(externalized_type)) = definition.externalized_type() else {
             unreachable!("slang externalizes every selector-bearing function's type");
         };
@@ -731,7 +746,7 @@ impl Call {
             &function.function_type.results,
             address,
             selector,
-            &Options::default(),
+            &options,
             true,
             is_static,
             is_guarded,
@@ -747,10 +762,12 @@ impl Call {
         definition: &FunctionDefinition,
         selector: u32,
         arguments: &[Expression],
+        options: Option<&CallOptions>,
         is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let function = scope.contract.source_unit.function_signature(definition);
+        let options = Options::new(options, scope);
         let mut converted = scope.external_arguments(
             std::slice::from_ref(&receiver),
             &function.function_type.parameters[..1],
@@ -773,7 +790,7 @@ impl Call {
             &result_types,
             address,
             selector,
-            &Options::default(),
+            &options,
             true,
             is_static,
             is_guarded,

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -477,7 +477,7 @@ impl Call {
         call: &FunctionCallExpression,
         arguments: &[Expression],
         options: Option<&CallOptions>,
-        guarded: bool,
+        is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> Value<'context> {
         let result_type = scope.typing(call.get_type());
@@ -494,7 +494,7 @@ impl Call {
         let converted = scope.external_arguments(arguments, &parameter_types);
         let amount = options.amount(scope);
         let object = Object::Contract(contract_definition.clone()).identifier();
-        let create = if guarded {
+        let create = if is_guarded {
             Value::create_contract_try
         } else {
             Value::create_contract
@@ -683,7 +683,7 @@ impl Call {
         function_type: &FunctionType,
         arguments: &[Expression],
         options: Option<&CallOptions>,
-        guarded: bool,
+        is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let address = scope.converted(&access.operand(), MlirType::address(scope.melior, false));
@@ -700,7 +700,7 @@ impl Call {
             &options,
             false,
             is_static,
-            guarded,
+            is_guarded,
             scope,
         )
     }
@@ -712,7 +712,7 @@ impl Call {
         definition: &FunctionDefinition,
         selector: u32,
         arguments: &[Expression],
-        guarded: bool,
+        is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let address = Self::library_address(definition, scope);
@@ -734,7 +734,7 @@ impl Call {
             &Options::default(),
             true,
             is_static,
-            guarded,
+            is_guarded,
             scope,
         )
     }
@@ -747,7 +747,7 @@ impl Call {
         definition: &FunctionDefinition,
         selector: u32,
         arguments: &[Expression],
-        guarded: bool,
+        is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let function = scope.contract.source_unit.function_signature(definition);
@@ -776,7 +776,7 @@ impl Call {
             &Options::default(),
             true,
             is_static,
-            guarded,
+            is_guarded,
             scope,
         )
     }
@@ -792,7 +792,7 @@ impl Call {
         Value::library_address(Object::Library(library).identifier().as_str(), scope)
     }
 
-    /// Emits the `sol.ext_call` an external dispatch selects: the `library_*` emitters carry
+    /// Emits the `sol.ext_call` an external dispatch selects: a library callee carries
     /// `delegate_call, library_call`, while `static_call` and the `try` wrapper are independent
     /// axes.
     fn external_dispatch<'context>(
@@ -804,23 +804,13 @@ impl Call {
         options: &Options<'context>,
         is_library: bool,
         is_static: bool,
-        guarded: bool,
+        is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let selector = Value::selector(selector, MlirType::field(scope.melior), scope);
         let gas = options.gas(scope);
         let amount = options.amount(scope);
-        let call = match (is_library, is_static, guarded) {
-            (false, false, false) => Function::external_call,
-            (false, true, false) => Function::external_static_call,
-            (false, false, true) => Function::external_try_call,
-            (false, true, true) => Function::external_static_try_call,
-            (true, false, false) => Function::library_call,
-            (true, true, false) => Function::library_static_call,
-            (true, false, true) => Function::library_try_call,
-            (true, true, true) => Function::library_static_try_call,
-        };
-        call(
+        Function::external_call(
             function,
             arguments,
             result_types,
@@ -828,6 +818,9 @@ impl Call {
             selector,
             gas,
             amount,
+            is_library,
+            is_static,
+            is_guarded,
             scope,
         )
     }
@@ -1116,7 +1109,7 @@ impl Call {
         function_type: &FunctionType,
         arguments: &[Expression],
         options: Option<&CallOptions>,
-        guarded: bool,
+        is_guarded: bool,
         scope: &mut FunctionScope<'_, '_, 'context>,
     ) -> (Value<'context>, Vec<Value<'context>>) {
         let MlirFunctionType {
@@ -1129,13 +1122,9 @@ impl Call {
         let gas = options.gas(scope);
         let amount = options.amount(scope);
         let is_static = StateMutability::from(function_type.mutability()).is_static();
-        let call = match (is_static, guarded) {
-            (false, false) => Value::external_call,
-            (true, false) => Value::external_static_call,
-            (false, true) => Value::external_try_call,
-            (true, true) => Value::external_static_try_call,
-        };
-        call(pointer, &converted, &results, gas, amount, scope)
+        Value::external_call(
+            pointer, &converted, &results, gas, amount, is_static, is_guarded, scope,
+        )
     }
 }
 

--- a/solx-slang/src/contract/function/expression/call/options.rs
+++ b/solx-slang/src/contract/function/expression/call/options.rs
@@ -24,8 +24,11 @@ pub struct Options<'context> {
 }
 
 impl<'context> Options<'context> {
-    /// Emits each option the call names, in source order.
-    pub fn new(options: &CallOptions, scope: &mut FunctionScope<'_, '_, 'context>) -> Self {
+    /// Emits each option the call names, in source order; an undecorated call forwards defaults.
+    pub fn new(options: Option<&CallOptions>, scope: &mut FunctionScope<'_, '_, 'context>) -> Self {
+        let Some(options) = options else {
+            return Self::default();
+        };
         let field = MlirType::field(scope.melior);
         let mut forwarded = Self::default();
         for option in options.iter() {

--- a/solx-slang/src/contract/function/expression/identifier.rs
+++ b/solx-slang/src/contract/function/expression/identifier.rs
@@ -11,11 +11,13 @@ use solx_mlir::Place;
 use solx_mlir::Type as MlirType;
 use solx_mlir::Value;
 
+use crate::contract::object::Object;
 use crate::scope::function::FunctionScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// A constant folds to its initializer; a bare function name materialises its internal pointer
-    /// (`sol.func_constant`); every other identifier loads from its place.
+    /// (`sol.func_constant`), defining the function in this module if absent; a library name is its
+    /// linked address (`sol.lib_addr`); every other identifier loads from its place.
     pub fn identifier(&mut self, node: &Identifier) -> Value<'context> {
         match node.resolve_to_definition() {
             Some(Definition::Constant(constant)) => {
@@ -33,11 +35,16 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                         .expect("a constant state variable is initialized"),
                 )
             }
-            Some(Definition::Function(function)) => self
-                .contract
-                .source_unit
-                .function_signature(function.node_id())
-                .pointer_constant(self),
+            Some(Definition::Function(function)) => {
+                self.contract.function_definition(&function);
+                self.contract
+                    .source_unit
+                    .function_signature(&function)
+                    .pointer_constant(self)
+            }
+            Some(Definition::Library(library)) => {
+                Value::library_address(Object::Library(library).identifier().as_str(), self)
+            }
             _ => {
                 let (place, element_type) = self.identifier_place(node);
                 place.load(element_type, self)

--- a/solx-slang/src/contract/function/expression/member.rs
+++ b/solx-slang/src/contract/function/expression/member.rs
@@ -6,6 +6,7 @@ use num::BigInt;
 use slang_solidity_v2::ast::BuiltIn;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::Expression;
+use slang_solidity_v2::ast::Identifier;
 use slang_solidity_v2::ast::MemberAccessExpression;
 use slang_solidity_v2::ast::Type;
 use slang_solidity_v2::ast::TypeName;
@@ -16,8 +17,8 @@ use solx_mlir::Value;
 use solx_utils::FunctionReferenceKind;
 
 use crate::contract::function::expression::call::external_callee::ExternalCallee;
+use crate::contract::object::Object;
 use crate::scope::function::FunctionScope;
-use crate::scope::source_unit::SourceUnitScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// A struct field loads from its place; an enum member is its ordinal; an externally visible
@@ -26,7 +27,10 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     pub fn member_access(&mut self, node: &MemberAccessExpression) -> Value<'context> {
         let operand = node.operand();
 
-        if matches!(operand.get_type(), Some(Type::Struct(_))) {
+        if matches!(
+            node.member().resolve_to_definition(),
+            Some(Definition::StructMember(_))
+        ) {
             let (place, element_type) = self.member_access_place(node);
             return place.load(element_type, self);
         }
@@ -63,19 +67,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             );
         }
 
-        if let Expression::Identifier(namespace) = &operand {
-            match namespace.resolve_to_definition() {
-                Some(Definition::Contract(_)) => return self.identifier(&node.member()),
-                Some(Definition::Library(_))
-                    if matches!(
-                        node.member().resolve_to_definition(),
-                        Some(Definition::Constant(_) | Definition::StateVariable(_))
-                    ) =>
-                {
-                    return self.identifier(&node.member());
-                }
-                _ => {}
-            }
+        if Self::is_namespace_member(&operand, &node.member()) {
+            return self.identifier(&node.member());
         }
 
         match node.member().resolve_to_built_in() {
@@ -122,7 +115,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 let name = match Self::meta_type_definition(&operand) {
                     Definition::Contract(contract) => contract.name(),
                     Definition::Interface(interface) => interface.name(),
-                    _ => unimplemented!("`type(..).name` names no contract or interface"),
+                    Definition::Library(library) => library.name(),
+                    _ => unreachable!("slang resolves `.name` on a code-bearing type alone"),
                 };
                 Value::string_literal(name.name().as_bytes(), self)
             }
@@ -139,29 +133,17 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 )
             }
             Some(BuiltIn::TypeCreationCode) => {
-                let Definition::Contract(contract) = Self::meta_type_definition(&operand) else {
-                    unimplemented!("`type(..).creationCode` names no contract");
-                };
-                let object = SourceUnitScope::object_identifier(
-                    contract.get_file_id(),
-                    contract.name().name(),
-                );
-                Value::object_code(object.as_str(), self)
+                Value::object_code(Self::meta_object_identifier(&operand).as_str(), self)
             }
-            Some(BuiltIn::TypeRuntimeCode) => {
-                let Definition::Contract(contract) = Self::meta_type_definition(&operand) else {
-                    unimplemented!("`type(..).runtimeCode` names no contract");
-                };
-                let object = format!(
+            Some(BuiltIn::TypeRuntimeCode) => Value::object_code(
+                format!(
                     "{}{}",
-                    SourceUnitScope::object_identifier(
-                        contract.get_file_id(),
-                        contract.name().name(),
-                    ),
+                    Self::meta_object_identifier(&operand),
                     solx_utils::Dependencies::DEPLOYED_OBJECT_SUFFIX,
-                );
-                Value::object_code(object.as_str(), self)
-            }
+                )
+                .as_str(),
+                self,
+            ),
             Some(BuiltIn::ErrorSelector) => {
                 let Some(Definition::Error(error)) = Self::resolved_definition(&operand) else {
                     unreachable!("`.selector` on an error names an error definition");
@@ -196,12 +178,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         node: &MemberAccessExpression,
     ) -> (Place<'context>, MlirType<'context>) {
         let base = node.operand();
-        if let Expression::Identifier(namespace) = &base
-            && matches!(
-                namespace.resolve_to_definition(),
-                Some(Definition::Contract(_))
-            )
-        {
+        if Self::is_namespace_member(&base, &node.member()) {
             return self.identifier_place(&node.member());
         }
         let Some(Type::Struct(struct_type)) = base.get_type() else {
@@ -243,13 +220,37 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         self.expression(operand).external_function_selector(self)
     }
 
+    /// Whether the member access qualifies a namespace (`C.x`, `L.f`, `M.Lib.K` — the operand may
+    /// chain aliases to any depth) and so resolves through its member alone: the namespace itself
+    /// denotes no value, and a selector-bearing library function is dispatched as an external
+    /// callee instead.
+    fn is_namespace_member(operand: &Expression, member: &Identifier) -> bool {
+        match Self::resolved_definition(operand) {
+            Some(Definition::Contract(_) | Definition::Import(_)) => true,
+            Some(Definition::Library(_)) => match member.resolve_to_definition() {
+                Some(Definition::Constant(_) | Definition::StateVariable(_)) => true,
+                Some(Definition::Function(function)) => function.compute_selector().is_none(),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    /// The object identifier of the contract or library `type(X)` names.
+    fn meta_object_identifier(operand: &Expression) -> String {
+        let Some(object) = Object::from_definition(Self::meta_type_definition(operand)) else {
+            unreachable!("slang resolves the code built-ins on a deployable object alone")
+        };
+        object.identifier()
+    }
+
     /// The definition `type(X)` names.
     fn meta_type_definition(operand: &Expression) -> Definition {
         let Expression::TypeExpression(type_expression) = operand else {
             unreachable!("the type built-ins decorate a `type(..)` expression");
         };
         let TypeName::IdentifierPath(path) = type_expression.type_name() else {
-            unreachable!("`type(..)` of a contract or interface names it by path");
+            unreachable!("`type(..)` of a contract, interface, or library names it by path");
         };
         path.resolve_to_definition()
             .expect("slang resolves the type `type(..)` names")

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -163,6 +163,13 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                         Definition::Contract(_) | Definition::Interface(_) | Definition::Library(_)
                     )
                 ) => {}
+            Expression::MemberAccessExpression(inner)
+                if matches!(
+                    Self::resolved_definition(&inner.operand()),
+                    Some(
+                        Definition::Contract(_) | Definition::Interface(_) | Definition::Library(_)
+                    )
+                ) => {}
             _ => {
                 self.expression(node);
             }

--- a/solx-slang/src/contract/function/mod.rs
+++ b/solx-slang/src/contract/function/mod.rs
@@ -21,21 +21,29 @@ use crate::scope::contract::ContractScope;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
-    /// Emits `function`'s `sol.func` into the contract body from its pre-registered signature,
-    /// binding parameters and named-return pointers into a fresh function frame. A constructor runs
-    /// the contract's state variable initializers as its prologue.
+    /// Defines `function`'s `sol.func` in the contract body at its first naming, binding
+    /// parameters and named-return pointers into a fresh function frame. A constructor runs the
+    /// contract's state variable initializers as its prologue. A function carries its dispatch
+    /// selector only in its owner's module, so a copied body never becomes an entry point.
     pub fn function_definition(&mut self, function: &FunctionDefinition) {
         let Some(body) = function.body() else {
             return;
         };
-        let signature = self.source_unit.function_signature(function.node_id());
+        if !self.defined_functions.insert(function.node_id()) {
+            return;
+        }
+        let selector = match function.enclosing_definition() {
+            Some(enclosing) if enclosing.node_id() == self.object_id => function.compute_selector(),
+            _ => None,
+        };
+        let signature = self.source_unit.function_signature(function);
         let state_mutability = StateMutability::from(function.attributes().mutability());
         let entry = signature.define(
-            function.compute_selector(),
+            selector,
             FunctionDispatch::from(function),
             state_mutability,
             self,
-            self.contract_body,
+            self.contract.body,
         );
         let FunctionType {
             parameters,
@@ -105,7 +113,7 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             FunctionDispatch::Kind(MlirFunctionKind::Constructor),
             StateMutability::NonPayable,
             self,
-            self.contract_body,
+            self.contract.body,
         );
         self.function(entry, Vec::new(), |scope| {
             scope.state_variable_initializers();

--- a/solx-slang/src/contract/getter/mod.rs
+++ b/solx-slang/src/contract/getter/mod.rs
@@ -128,7 +128,7 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     FunctionDispatch::Getter,
                     StateMutability::Pure,
                     self,
-                    self.contract_body,
+                    self.contract.body,
                 );
                 self.function(entry, signature.function_type.results, |scope| {
                     let result_type = scope.return_types[0];
@@ -149,7 +149,7 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     FunctionDispatch::Getter,
                     StateMutability::View,
                     self,
-                    self.contract_body,
+                    self.contract.body,
                 );
                 self.function(entry, signature.function_type.results, |scope| {
                     let (place, _) = scope.state_variable_place(state_variable, &slot_name);

--- a/solx-slang/src/contract/mod.rs
+++ b/solx-slang/src/contract/mod.rs
@@ -1,160 +1,74 @@
 //!
-//! Contract definition emission to Sol dialect MLIR.
+//! Contract and library definition emission to Sol dialect MLIR.
 //!
 
 pub mod function;
 pub mod getter;
+pub mod object;
 pub mod state_variable;
 pub mod storage_slot;
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
-
-use slang_solidity_v2::ast::ContractDefinition;
-use slang_solidity_v2::ast::ContractMember;
-use slang_solidity_v2::ast::FunctionDefinition;
-use slang_solidity_v2::ast::FunctionKind;
-use slang_solidity_v2::ast::StateVariableDefinition;
-use slang_solidity_v2::ast::Type;
-use slang_solidity_v2::compilation::FileId;
 
 use solx_mlir::Block;
 use solx_mlir::Contract;
-use solx_mlir::Function;
 use solx_mlir::Type as MlirType;
 
-use crate::contract::storage_slot::StorageSlot;
+use crate::contract::object::Object;
+use crate::scope::contract::ContractScope;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'context> SourceUnitScope<'context> {
-    /// Emits a `sol.contract` wrapping a `sol.func` per function and returns the contract's ABI
-    /// `method_identifiers` map (externally-dispatchable signature to 4-byte selector, lower-case
-    /// hex); `convert-sol-to-yul` builds the entry-point dispatcher from the function selectors.
-    /// Function signatures are pre-registered for call resolution before any body is emitted.
-    /// `operator_functions` land in the contract body because MLIR has no file scope.
-    pub fn contract_definition(
-        &mut self,
-        node: &ContractDefinition,
-        operator_functions: &[FunctionDefinition],
-    ) -> BTreeMap<String, String> {
-        let contract_identifier = node.name();
-
-        for function in node
-            .functions()
-            .into_iter()
-            .chain(node.constructor())
-            .chain(operator_functions.iter().cloned())
-        {
-            let Some(Type::Function(function_type)) = function.get_type() else {
-                unreachable!("slang types every function definition");
-            };
-            self.function_signatures.insert(
-                function.node_id(),
-                Function::new(
-                    Self::function_symbol(&function),
-                    self.function_type(&function_type),
-                ),
-            );
-        }
-
-        let state_variables: Vec<StateVariableDefinition> = node
-            .members()
-            .iter()
-            .filter_map(|member| match member {
-                ContractMember::StateVariableDefinition(state_variable) => {
-                    Some(state_variable.clone())
-                }
-                _ => None,
-            })
-            .collect();
-        let public_state_variables: Vec<StateVariableDefinition> = state_variables
-            .iter()
-            .filter(|state_variable| state_variable.is_externally_visible())
-            .cloned()
-            .collect();
-        let storage_layout = match node.compute_abi() {
-            Some(abi) => abi
-                .storage_layout()
-                .iter()
-                .map(|item| (item.node_id(), StorageSlot::from(item)))
-                .collect(),
-            None => HashMap::new(),
-        };
-
-        let object_identifier =
-            Self::object_identifier(node.get_file_id(), contract_identifier.name());
-        let sol_contract = Contract::define(
-            object_identifier.as_str(),
-            solx_mlir::ContractKind::Contract,
+    /// Emits `object`'s `sol.contract` and returns its ABI `method_identifiers` map.
+    pub fn object_definition(&mut self, object: &Object) -> BTreeMap<String, String> {
+        let identifier = object.identifier();
+        let contract = Contract::define(
+            identifier.as_str(),
+            object.kind(),
             self,
             Block::from(self.module.body()),
         );
         self.contract(
-            MlirType::contract(self.melior, object_identifier.as_str(), node.is_payable()),
-            sol_contract.body,
-            state_variables,
-            storage_layout,
-            |scope| {
-                for state_variable in scope.state_variables.iter() {
-                    let Some(slot) = scope.storage_layout.get(&state_variable.node_id()) else {
-                        continue;
-                    };
-                    let element_type = scope.source_unit.resolve(
-                        &state_variable
-                            .get_type()
-                            .expect("binder types every state variable"),
-                        None,
-                    );
-                    sol_contract.declare_state_var(
-                        &slot.name,
-                        element_type,
-                        slot.slot,
-                        slot.byte_offset,
-                        scope,
-                    );
-                }
-                scope.constructor(node);
-                for function in node.functions().iter().chain(operator_functions) {
-                    scope.function_definition(function);
-                }
-                for state_variable in public_state_variables.iter() {
-                    scope.state_variable_getter(state_variable);
-                }
-            },
+            MlirType::contract(self.melior, identifier.as_str(), object.is_payable()),
+            contract,
+            object,
+            |scope| scope.members(object),
         );
 
-        node.functions()
-            .into_iter()
-            .filter(|function| {
-                matches!(function.kind(), FunctionKind::Regular) && function.is_externally_visible()
-            })
-            .map(|function| {
-                (
-                    function
-                        .compute_canonical_signature()
-                        .expect("an externally visible function has a canonical signature"),
-                    function
-                        .compute_selector()
-                        .expect("an externally visible function has a selector"),
-                )
-            })
-            .chain(public_state_variables.iter().map(|state_variable| {
-                (
-                    state_variable
-                        .compute_canonical_signature()
-                        .expect("a public state variable has a canonical signature"),
-                    state_variable
-                        .compute_selector()
-                        .expect("a public state variable has a selector"),
-                )
-            }))
-            .map(|(signature, selector)| (signature, format!("{selector:08x}")))
-            .collect()
+        object.method_identifiers()
     }
+}
 
-    /// The contract's object identifier, qualified by its file: linking keys objects by it, and two
-    /// files may declare the same name.
-    pub fn object_identifier(file_id: &FileId, name: &str) -> String {
-        solx_utils::ContractName::full_path(file_id.as_str(), name)
+impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
+    /// Emits the object's members: the state-variable declarations, the contract's constructor,
+    /// the functions, and the getters.
+    fn members(&mut self, object: &Object) {
+        for state_variable in self.state_variables.iter() {
+            let Some(slot) = self.storage_layout.get(&state_variable.node_id()) else {
+                continue;
+            };
+            let element_type = self.source_unit.resolve(
+                &state_variable
+                    .get_type()
+                    .expect("binder types every state variable"),
+                None,
+            );
+            self.contract.declare_state_var(
+                &slot.name,
+                element_type,
+                slot.slot,
+                slot.byte_offset,
+                self,
+            );
+        }
+        if let Object::Contract(node) = object {
+            self.constructor(node);
+        }
+        for function in object.functions().iter() {
+            self.function_definition(function);
+        }
+        for state_variable in object.public_state_variables() {
+            self.state_variable_getter(&state_variable);
+        }
     }
 }

--- a/solx-slang/src/contract/object.rs
+++ b/solx-slang/src/contract/object.rs
@@ -1,0 +1,157 @@
+//!
+//! The deployable object a module emits: a contract or a library.
+//!
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use slang_solidity_v2::ast::ContractDefinition;
+use slang_solidity_v2::ast::Definition;
+use slang_solidity_v2::ast::FunctionDefinition;
+use slang_solidity_v2::ast::FunctionKind;
+use slang_solidity_v2::ast::Identifier;
+use slang_solidity_v2::ast::LibraryDefinition;
+use slang_solidity_v2::ast::NodeId;
+use slang_solidity_v2::ast::StateVariableDefinition;
+
+use solx_mlir::ContractKind;
+
+use crate::contract::storage_slot::StorageSlot;
+
+/// The deployable object a module emits, each variant carrying the definition its kind
+/// dispatches from.
+pub enum Object {
+    /// A contract: storage, a constructor, selector dispatch.
+    Contract(ContractDefinition),
+    /// A library: no storage, no constructor, `DELEGATECALL` dispatch.
+    Library(LibraryDefinition),
+}
+
+impl Object {
+    /// Classifies the definition a name resolves to, admitting the two that deploy an object.
+    pub fn from_definition(definition: Definition) -> Option<Self> {
+        match definition {
+            Definition::Contract(contract) => Some(Self::Contract(contract)),
+            Definition::Library(library) => Some(Self::Library(library)),
+            _ => None,
+        }
+    }
+
+    /// The object's definition id.
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Self::Contract(node) => node.node_id(),
+            Self::Library(node) => node.node_id(),
+        }
+    }
+
+    /// The object's name.
+    pub fn name(&self) -> Identifier {
+        match self {
+            Self::Contract(node) => node.name(),
+            Self::Library(node) => node.name(),
+        }
+    }
+
+    /// The object's identifier, qualified by its file: linking keys objects by it, and two files
+    /// may declare the same name.
+    pub fn identifier(&self) -> String {
+        let file_id = match self {
+            Self::Contract(node) => node.get_file_id(),
+            Self::Library(node) => node.get_file_id(),
+        };
+        solx_utils::ContractName::full_path(file_id.as_str(), self.name().name())
+    }
+
+    /// The kind the object's `sol.contract` declares.
+    pub fn kind(&self) -> ContractKind {
+        match self {
+            Self::Contract(_) => ContractKind::Contract,
+            Self::Library(_) => ContractKind::Library,
+        }
+    }
+
+    /// Whether the object accepts value: a library is reached by `DELEGATECALL` alone, which
+    /// carries the caller's.
+    pub fn is_payable(&self) -> bool {
+        match self {
+            Self::Contract(node) => node.is_payable(),
+            Self::Library(_) => false,
+        }
+    }
+
+    /// The object's own functions.
+    pub fn functions(&self) -> Vec<FunctionDefinition> {
+        match self {
+            Self::Contract(node) => node.functions(),
+            Self::Library(node) => node.functions(),
+        }
+    }
+
+    /// The object's state variable declarations in source order.
+    pub fn state_variables(&self) -> Vec<StateVariableDefinition> {
+        match self {
+            Self::Contract(node) => node.state_variables(),
+            Self::Library(node) => node.state_variables(),
+        }
+    }
+
+    /// The state variables a getter dispatches to.
+    pub fn public_state_variables(&self) -> Vec<StateVariableDefinition> {
+        self.state_variables()
+            .into_iter()
+            .filter(|state_variable| state_variable.is_externally_visible())
+            .collect()
+    }
+
+    /// The storage slot of each state variable the object stores, keyed by definition id. A
+    /// library declares only constants, which occupy no slot.
+    pub fn storage_layout(&self) -> HashMap<NodeId, StorageSlot> {
+        match self {
+            Self::Contract(node) => node
+                .compute_abi()
+                .map(|abi| {
+                    abi.storage_layout()
+                        .iter()
+                        .map(|item| (item.node_id(), StorageSlot::from(item)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Self::Library(_) => HashMap::new(),
+        }
+    }
+
+    /// The ABI `method_identifiers` map (externally dispatchable signature to 4-byte selector,
+    /// lower-case hex): each function keyed by the signature its selector hashes, each public
+    /// state variable by its canonical one. `convert-sol-to-yul` builds the entry-point
+    /// dispatcher from the function selectors.
+    pub fn method_identifiers(&self) -> BTreeMap<String, String> {
+        self.functions()
+            .iter()
+            .filter(|function| {
+                matches!(function.kind(), FunctionKind::Regular) && function.is_externally_visible()
+            })
+            .map(|function| {
+                (
+                    function
+                        .compute_selector_signature()
+                        .expect("an externally visible function has a selector signature"),
+                    function
+                        .compute_selector()
+                        .expect("an externally visible function has a selector"),
+                )
+            })
+            .chain(self.public_state_variables().iter().map(|state_variable| {
+                (
+                    state_variable
+                        .compute_canonical_signature()
+                        .expect("a public state variable has a canonical signature"),
+                    state_variable
+                        .compute_selector()
+                        .expect("a public state variable has a selector"),
+                )
+            }))
+            .map(|(signature, selector)| (signature, format!("{selector:08x}")))
+            .collect()
+    }
+}

--- a/solx-slang/src/scope/contract.rs
+++ b/solx-slang/src/scope/contract.rs
@@ -1,9 +1,10 @@
 //!
-//! The contract scope: the enclosing source unit scope, the block the contract's functions are
+//! The contract scope: the enclosing source unit scope, the `sol.contract` the members are
 //! defined into, and the state-variable data a member resolves against.
 //!
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ops::Deref;
 
 use slang_solidity_v2::ast::NodeId;
@@ -11,19 +12,25 @@ use slang_solidity_v2::ast::StateVariableDefinition;
 
 use solx_mlir::Block;
 use solx_mlir::Context;
+use solx_mlir::Contract;
 use solx_mlir::Type as MlirType;
 
+use crate::contract::object::Object;
 use crate::contract::storage_slot::StorageSlot;
 use crate::scope::function::FunctionScope;
 use crate::scope::source_unit::SourceUnitScope;
 
-/// The contract scope: the enclosing source unit scope, the block the contract's functions are
+/// The contract scope: the enclosing source unit scope, the `sol.contract` the members are
 /// defined into, and the state-variable data a member resolves against.
 pub struct ContractScope<'source_unit, 'context> {
     /// The source unit scope this contract is lowered within.
     pub source_unit: &'source_unit mut SourceUnitScope<'context>,
-    /// The block the contract's `sol.func`s are defined into.
-    pub contract_body: Block<'context>,
+    /// The `sol.contract` the members are declared and defined into.
+    pub contract: Contract<'context>,
+    /// The definition id of the object being emitted.
+    pub object_id: NodeId,
+    /// The definition ids of the functions the contract defines.
+    pub defined_functions: HashSet<NodeId>,
     /// The contract's state variable definitions in declaration order.
     pub state_variables: Vec<StateVariableDefinition>,
     /// The state-variable slots keyed by definition id.
@@ -34,15 +41,16 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
     /// Opens a contract scope within `source_unit`.
     pub fn new(
         source_unit: &'source_unit mut SourceUnitScope<'context>,
-        contract_body: Block<'context>,
-        state_variables: Vec<StateVariableDefinition>,
-        storage_layout: HashMap<NodeId, StorageSlot>,
+        contract: Contract<'context>,
+        object: &Object,
     ) -> Self {
         Self {
             source_unit,
-            contract_body,
-            state_variables,
-            storage_layout,
+            contract,
+            object_id: object.node_id(),
+            defined_functions: HashSet::new(),
+            state_variables: object.state_variables(),
+            storage_layout: object.storage_layout(),
         }
     }
 

--- a/solx-slang/src/scope/source_unit.rs
+++ b/solx-slang/src/scope/source_unit.rs
@@ -5,23 +5,23 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
+use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::NodeId;
-use slang_solidity_v2::ast::StateVariableDefinition;
+use slang_solidity_v2::ast::Type;
 
-use solx_mlir::Block;
 use solx_mlir::Context;
+use solx_mlir::Contract;
 use solx_mlir::Function;
 use solx_mlir::Type as MlirType;
 
-use crate::contract::storage_slot::StorageSlot;
+use crate::contract::object::Object;
 use crate::scope::contract::ContractScope;
 
-/// The source unit scope: the owned MLIR context that every nested scope emits into, and the
-/// signatures of the functions lowered within it.
+/// The source unit scope: the owned MLIR context that every nested scope emits into.
 pub struct SourceUnitScope<'context> {
     /// The owned MLIR context, surrendered by the conversion into it.
     pub mlir: Context<'context>,
-    /// The function signatures keyed by the AST definition id of each function.
+    /// The mangled symbol and MLIR signature of each function, filled at its first naming.
     pub function_signatures: HashMap<NodeId, Function<'context>>,
 }
 
@@ -34,33 +34,36 @@ impl<'context> SourceUnitScope<'context> {
         }
     }
 
-    /// Opens the contract scope around `emit`: the body an enclosed function is defined into, the
-    /// state variables and storage layout it resolves against, with the `this` type installed on
-    /// the MLIR context for its duration.
+    /// Opens the contract scope around `emit`: the `sol.contract` an enclosed member is defined
+    /// into, the state variables and storage layout it resolves against, with the `this` type
+    /// installed on the MLIR context for its duration.
     pub fn contract(
         &mut self,
         contract_type: MlirType<'context>,
-        body: Block<'context>,
-        state_variables: Vec<StateVariableDefinition>,
-        storage_layout: HashMap<NodeId, StorageSlot>,
+        contract: Contract<'context>,
+        object: &Object,
         emit: impl FnOnce(&mut ContractScope<'_, 'context>),
     ) {
         self.mlir.current_contract_type = Some(contract_type);
-        emit(&mut ContractScope::new(
-            self,
-            body,
-            state_variables,
-            storage_layout,
-        ));
+        emit(&mut ContractScope::new(self, contract, object));
         self.mlir.current_contract_type = None;
     }
 
-    /// The pre-registered signature of `definition_node_id`'s function.
-    pub fn function_signature(&self, definition_node_id: NodeId) -> Function<'context> {
+    /// The function's mangled symbol and MLIR signature, computed at its first naming.
+    pub fn function_signature(&mut self, function: &FunctionDefinition) -> Function<'context> {
+        if let Some(signature) = self.function_signatures.get(&function.node_id()) {
+            return signature.clone();
+        }
+        let Some(Type::Function(function_type)) = function.get_type() else {
+            unreachable!("slang types every function definition");
+        };
+        let signature = Function::new(
+            Self::function_symbol(function),
+            self.function_type(&function_type),
+        );
         self.function_signatures
-            .get(&definition_node_id)
-            .cloned()
-            .expect("the contract lowering pre-registers every function")
+            .insert(function.node_id(), signature.clone());
+        signature
     }
 }
 

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -1,89 +1,64 @@
 //!
-//! Source unit emission: lowering a file's contracts through the per-file MLIR scope.
+//! Source unit emission: lowering a file's contracts and libraries through the per-file MLIR
+//! scope.
 //!
 
 use std::collections::BTreeMap;
 
-use itertools::Itertools;
 use slang_solidity_v2::ast::ContractBase;
-use slang_solidity_v2::ast::Definition;
-use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::SourceUnit;
 use slang_solidity_v2::ast::SourceUnitMember;
-use slang_solidity_v2::ast::UsingClause;
 
 use solx_mlir::Context;
 use solx_standard_json::output::contract::Contract;
 use solx_utils::EVMVersion;
 
+use crate::contract::object::Object;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'context> SourceUnitScope<'context> {
-    /// Lowers every contract the unit deploys into standard-JSON contract outputs keyed by contract
-    /// name, each in its own MLIR module off the file's melior context. An abstract contract and an
-    /// interface deploy nothing and produce no module. A contract with a contract base is skipped
-    /// because emission collects only the contract's own state and functions: an interface base
-    /// carries nothing to inherit, a contract base carries state and bodies that would be silently
-    /// dropped.
+    /// Lowers every contract and library the unit deploys into standard-JSON contract outputs
+    /// keyed by definition name, each in its own MLIR module off the file's melior context. An
+    /// abstract contract and an interface deploy nothing and produce no module. A contract with a
+    /// contract base is skipped because emission collects only the contract's own state and
+    /// functions: an interface base carries nothing to inherit, a contract base carries state and
+    /// bodies that would be silently dropped.
     ///
     /// # Errors
     ///
     /// Returns an error if module finalization fails.
     // TODO: emit a contract inheriting from a contract, which needs its inherited state variables
-    // and functions, and a library, whose own address reaches LLVM through the untranslated
-    // `llvm.setimmutable`.
+    // and functions.
     pub fn source_unit(
         unit: &SourceUnit,
         evm_version: EVMVersion,
         capture_sol_dialect: impl Fn(&str) -> bool,
     ) -> anyhow::Result<BTreeMap<String, Contract>> {
-        let operator_functions = Self::operator_bound_functions(unit);
         let melior = Context::create_melior_context();
         let mut contracts = BTreeMap::new();
-        for contract in unit.contracts().iter().filter(|contract| {
-            !contract.is_abstract()
-                && !contract.direct_bases().iter().any(|base| match base {
-                    ContractBase::Contract(_) => true,
-                    ContractBase::Interface(_) => false,
-                })
-        }) {
+        for member in unit.members().iter() {
+            let object = match member {
+                SourceUnitMember::ContractDefinition(contract)
+                    if !contract.is_abstract()
+                        && !contract.direct_bases().iter().any(|base| match base {
+                            ContractBase::Contract(_) => true,
+                            ContractBase::Interface(_) => false,
+                        }) =>
+                {
+                    Object::Contract(contract.clone())
+                }
+                SourceUnitMember::LibraryDefinition(library) => Object::Library(library.clone()),
+                _ => continue,
+            };
             let mut scope = SourceUnitScope::new(Context::new(&melior, evm_version));
-            let method_identifiers = scope.contract_definition(contract, &operator_functions);
-
-            let name = contract.name().name().to_owned();
-            let object_identifier = Self::object_identifier(contract.get_file_id(), name.as_str());
+            let method_identifiers = scope.object_definition(&object);
+            let name = object.name().name().to_owned();
             let mlir = Context::from(scope).finalize_module(
-                object_identifier.as_str(),
+                object.identifier().as_str(),
                 capture_sol_dialect(name.as_str()),
             )?;
             contracts.insert(name, Contract::new_mlir(mlir, method_identifiers));
         }
         Ok(contracts)
-    }
-
-    /// The functions `unit`'s `using {f as op} for T global;` directives bind operators to, in
-    /// source order and without repeats. A binding reaches the whole compilation unit, so a
-    /// function bound from another file is missing here.
-    // TODO: add support for cross-file binding of operator functions
-    fn operator_bound_functions(unit: &SourceUnit) -> Vec<FunctionDefinition> {
-        unit.members()
-            .iter()
-            .filter_map(|member| match member {
-                SourceUnitMember::UsingDirective(directive) if directive.is_global() => {
-                    match directive.clause() {
-                        UsingClause::UsingDeconstruction(deconstruction) => Some(deconstruction),
-                        UsingClause::IdentifierPath(_) => None,
-                    }
-                }
-                _ => None,
-            })
-            .flat_map(|deconstruction| deconstruction.symbols().iter().collect::<Vec<_>>())
-            .filter(|symbol| symbol.alias().is_some())
-            .filter_map(|symbol| match symbol.name().resolve_to_definition()? {
-                Definition::Function(function) => Some(function),
-                _ => None,
-            })
-            .unique_by(|function| function.node_id())
-            .collect()
     }
 }

--- a/solx-slang/src/type.rs
+++ b/solx-slang/src/type.rs
@@ -134,35 +134,9 @@ impl<'context> SourceUnitScope<'context> {
                     .collect();
                 MlirType::structure(self.melior, &member_types, struct_location)
             }
-            Type::Contract(contract_type) => {
-                let Definition::Contract(contract_definition) = contract_type.definition() else {
-                    unreachable!("Slang ContractType always references a Contract definition");
-                };
-                MlirType::contract(
-                    self.melior,
-                    Self::object_identifier(
-                        contract_definition.get_file_id(),
-                        contract_definition.name().name(),
-                    )
-                    .as_str(),
-                    contract_definition.is_payable(),
-                )
-            }
-            Type::Interface(interface_type) => {
-                let Definition::Interface(interface_definition) = interface_type.definition()
-                else {
-                    unreachable!("Slang InterfaceType always references an Interface definition");
-                };
-                MlirType::contract(
-                    self.melior,
-                    Self::object_identifier(
-                        interface_definition.get_file_id(),
-                        interface_definition.name().name(),
-                    )
-                    .as_str(),
-                    false,
-                )
-            }
+            Type::Contract(inner) => self.object_type(inner.definition()),
+            Type::Interface(inner) => self.object_type(inner.definition()),
+            Type::Library(inner) => self.object_type(inner.definition()),
             Type::Enum(enum_type) => {
                 let Definition::Enum(enum_definition) = enum_type.definition() else {
                     unreachable!("Slang EnumType always references an Enum definition");
@@ -232,5 +206,21 @@ impl<'context> SourceUnitScope<'context> {
             return element_type;
         }
         MlirType::pointer(self.melior, element_type, base_location)
+    }
+
+    /// The Sol dialect type a value of an object type carries: the object identifier it is linked
+    /// by. Only a contract declares the payable dispatch that lets a plain transfer reach it.
+    fn object_type(&self, definition: Definition) -> MlirType<'context> {
+        let (file_id, name, is_payable) = match &definition {
+            Definition::Contract(node) => (node.get_file_id(), node.name(), node.is_payable()),
+            Definition::Interface(node) => (node.get_file_id(), node.name(), false),
+            Definition::Library(node) => (node.get_file_id(), node.name(), false),
+            _ => unreachable!("slang types an object type by its own definition"),
+        };
+        MlirType::contract(
+            self.melior,
+            solx_utils::ContractName::full_path(file_id.as_str(), name.name()).as_str(),
+            is_payable,
+        )
     }
 }


### PR DESCRIPTION
Lowers libraries end to end: external delegatecall dispatch, internal calls by copy, the deployable library object, library-as-value expressions, and `--libraries` linking.

`cargo run-tester-slang`: 9505 → 10022 passed.