### PR TITLE
feat(slang): constant folding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1723,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3035,7 +3035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4029,7 +4029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4086,7 +4086,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4567,7 +4567,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4611,12 +4611,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=a1ade1c6642d2535fdb107848759b41341bbb205#a1ade1c6642d2535fdb107848759b41341bbb205"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=d14badacfacf8d1db1f610d12038abc18e169736#d14badacfacf8d1db1f610d12038abc18e169736"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -5000,7 +5000,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5135,7 +5134,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5144,7 +5143,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5775,7 +5774,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "a1ade1c6642d2535fdb107848759b41341bbb205"
+rev = "d14badacfacf8d1db1f610d12038abc18e169736"

--- a/solx-mlir/tests/lit/constant_expressions.sol
+++ b/solx-mlir/tests/lit/constant_expressions.sol
@@ -1,5 +1,6 @@
 // RUN: solx --emit-mlir=sol %s | FileCheck %s
-// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// solc emits operands in the different order, so this test is solx-only.
 
 // CHECK: sol.func @{{.*add.*}}() -> ui256
 // CHECK:   %{{.*}} = sol.constant 5 : ui8
@@ -48,6 +49,29 @@
 // CHECK:   %{{.*}} = sol.cmp ge, %{{.*}}, %{{.*}} : ui8
 // CHECK:   sol.return %{{.*}} : i1
 
+// CHECK: sol.func @{{.*fractional.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 750000000000000000 : ui64
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui64 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*fractional_compared.*}}() -> i1
+// CHECK:   sol.constant 1000000000000000000 : ui64
+// CHECK:   sol.constant 500000000000000000 : ui64
+// CHECK:   %{{.*}} = sol.cmp lt, %{{.*}}, %{{.*}} : ui64
+// CHECK:   sol.return %{{.*}} : i1
+
+// CHECK: sol.func @{{.*mixed_denominations.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 500000000000000001 : ui64
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui64 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*mixed_compared.*}}() -> i1
+// CHECK:   %{{.*}} = sol.constant 1 : ui8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui8 to ui64
+// CHECK:   %{{.*}} = sol.constant 500000000000000000 : ui64
+// CHECK:   %{{.*}} = sol.cmp gt, %{{.*}}, %{{.*}} : ui64
+// CHECK:   sol.return %{{.*}} : i1
+
 contract C {
     function add() public pure returns (uint256) {
         return 2 + 3;
@@ -87,5 +111,21 @@ contract C {
 
     function compared() public pure returns (bool) {
         return 3 / 2 * 4 >= 12 / 2;
+    }
+
+    function fractional() public pure returns (uint256) {
+        return 0.5 ether + 0.25 ether;
+    }
+
+    function fractional_compared() public pure returns (bool) {
+        return 0.5 ether < 1 ether;
+    }
+
+    function mixed_denominations() public pure returns (uint256) {
+        return 0.5 ether + 1 wei;
+    }
+
+    function mixed_compared() public pure returns (bool) {
+        return 0.5 ether > 1 wei;
     }
 }

--- a/solx-mlir/tests/lit/constant_expressions.sol
+++ b/solx-mlir/tests/lit/constant_expressions.sol
@@ -1,0 +1,91 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*add.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 5 : ui8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*rational.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 6 : ui8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui8 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*signed_mod.*}}() -> si256
+// CHECK:   %{{.*}} = sol.constant -2 : si8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : si8 to si256
+// CHECK:   sol.return %{{.*}} : si256
+
+// CHECK: sol.func @{{.*full_word.*}}() -> ui256
+// CHECK:   %[[MAX:.*]] = sol.constant 115792089237316195423570985008687907853269984665640564039457584007913129639935 : ui256
+// CHECK:   sol.return %[[MAX]] : ui256
+
+// CHECK: sol.func @{{.*shifted.*}}() -> ui256
+// CHECK:   %[[SHIFT:.*]] = sol.constant 1809251394333065553493296640760748560207343510400633813116524750123642650624 : ui256
+// CHECK:   sol.return %[[SHIFT]] : ui256
+
+// CHECK: sol.func @{{.*complemented.*}}() -> si256
+// CHECK:   %{{.*}} = sol.constant -6 : si8
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : si8 to si256
+// CHECK:   sol.return %{{.*}} : si256
+
+// CHECK: sol.func @{{.*denominated.*}}() -> ui256
+// CHECK:   %{{.*}} = sol.constant 1000000000000000001 : ui64
+// CHECK:   %{{.*}} = sol.cast %{{.*}} : ui64 to ui256
+// CHECK:   sol.return %{{.*}} : ui256
+
+// CHECK: sol.func @{{.*narrow.*}}() -> ui8
+// CHECK:   %[[FULL:.*]] = sol.constant 255 : ui8
+// CHECK:   sol.return %[[FULL]] : ui8
+
+// CHECK: sol.func @{{.*lowest.*}}() -> si256
+// CHECK:   %[[MIN:.*]] = sol.constant -57896044618658097711785492504343953926634992332820282019728792003956564819968 : si256
+// CHECK:   sol.return %[[MIN]] : si256
+
+// CHECK: sol.func @{{.*compared.*}}() -> i1
+// CHECK:   sol.constant 6 : ui8
+// CHECK:   sol.constant 6 : ui8
+// CHECK:   %{{.*}} = sol.cmp ge, %{{.*}}, %{{.*}} : ui8
+// CHECK:   sol.return %{{.*}} : i1
+
+contract C {
+    function add() public pure returns (uint256) {
+        return 2 + 3;
+    }
+
+    function rational() public pure returns (uint256) {
+        return 3 / 2 * 4;
+    }
+
+    function signed_mod() public pure returns (int256) {
+        return -5 % 3;
+    }
+
+    function full_word() public pure returns (uint256) {
+        return 2**256 - 1;
+    }
+
+    function shifted() public pure returns (uint256) {
+        return 1 << 250;
+    }
+
+    function complemented() public pure returns (int256) {
+        return ~5;
+    }
+
+    function denominated() public pure returns (uint256) {
+        return 1 ether + 1 wei;
+    }
+
+    function narrow() public pure returns (uint8) {
+        return 250 + 5;
+    }
+
+    function lowest() public pure returns (int256) {
+        return -2**255;
+    }
+
+    function compared() public pure returns (bool) {
+        return 3 / 2 * 4 >= 12 / 2;
+    }
+}

--- a/solx-slang/src/contract/function/expression/literal.rs
+++ b/solx-slang/src/contract/function/expression/literal.rs
@@ -1,8 +1,7 @@
 //!
-//! Literal expressions: integer numbers, the boolean keywords, and strings.
+//! Literal expressions: the boolean keywords and strings.
 //!
 
-use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::StringExpression;
 
 use solx_mlir::Value;
@@ -13,24 +12,6 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     /// The `true`/`false` keyword literals.
     pub fn boolean_literal(&mut self, value: bool) -> Value<'context> {
         Value::boolean(value, self)
-    }
-
-    /// A decimal or hexadecimal integer literal, folded to a constant of the binder's type. The two
-    /// literal kinds share this lowering; the enum is matched only to reach the concrete node whose
-    /// `integer_value` and `get_type` read different terminals.
-    pub fn number_literal(&mut self, node: &Expression) -> Value<'context> {
-        let (value, slang_type) = match node {
-            Expression::DecimalNumberExpression(number) => {
-                (number.integer_value(), number.get_type())
-            }
-            Expression::HexNumberExpression(number) => (number.integer_value(), number.get_type()),
-            _ => unreachable!("only decimal and hexadecimal literals lower as number literals"),
-        };
-        Value::constant_from_bigint(
-            &value.expect("an integer literal evaluates to an integer"),
-            self.typing(slang_type),
-            self,
-        )
     }
 
     /// A string literal, lowered to its Sol dialect string value.

--- a/solx-slang/src/contract/function/expression/mod.rs
+++ b/solx-slang/src/contract/function/expression/mod.rs
@@ -20,6 +20,7 @@ pub mod unary;
 
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::Expression;
+use slang_solidity_v2::ast::Number;
 use slang_solidity_v2::ast::Type;
 
 use solx_mlir::Place;
@@ -31,13 +32,17 @@ use crate::scope::function::FunctionScope;
 use self::call::Call;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// Lowers an expression to its single MLIR value, routing each kind to its lowering. A call in
+    /// Lowers an expression to its single MLIR value, routing each kind to its lowering. An
+    /// expression the binder folded to an integer constant materializes it directly. A call in
     /// value position takes its one result.
     pub fn expression(&mut self, node: &Expression) -> Value<'context> {
+        let slang_type = node.get_type();
+        if let Some(Type::Literal(literal_type)) = &slang_type
+            && let Some(Number::Integer(value)) = Number::from_literal_kind(&literal_type.kind())
+        {
+            return Value::constant_from_bigint(&value, self.typing(slang_type), self);
+        }
         match node {
-            Expression::DecimalNumberExpression(_) | Expression::HexNumberExpression(_) => {
-                self.number_literal(node)
-            }
             Expression::TrueKeyword(_) => self.boolean_literal(true),
             Expression::FalseKeyword(_) => self.boolean_literal(false),
             Expression::StringExpression(inner) => self.string_literal(inner),
@@ -70,6 +75,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 .into_iter()
                 .next()
                 .expect("a call in value position yields a value"),
+            Expression::DecimalNumberExpression(_) | Expression::HexNumberExpression(_) => {
+                unreachable!("the binder folds every number literal to an integer constant")
+            }
             Expression::CallOptionsExpression(_) => {
                 unreachable!("call options reach the call they decorate, never a value position")
             }

--- a/solx-slang/src/contract/function/expression/unary.rs
+++ b/solx-slang/src/contract/function/expression/unary.rs
@@ -37,18 +37,8 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             }
             PrefixExpressionOperator::Minus(_) => {
                 let result_type = self.typing(node.get_type());
-                let magnitude = match node.operand() {
-                    Expression::DecimalNumberExpression(number) => number.integer_value(),
-                    Expression::HexNumberExpression(number) => number.integer_value(),
-                    _ => None,
-                };
-                Some(match magnitude {
-                    Some(magnitude) => Value::constant_from_bigint(&-magnitude, result_type, self),
-                    None => {
-                        let value = self.converted(&node.operand(), result_type);
-                        Value::zero(result_type, self).subtract(value, self.checked, self)
-                    }
-                })
+                let value = self.converted(&node.operand(), result_type);
+                Some(Value::zero(result_type, self).subtract(value, self.checked, self))
             }
             PrefixExpressionOperator::DeleteKeyword(_) => {
                 self.delete(&node.operand());

--- a/solx-slang/src/type.rs
+++ b/solx-slang/src/type.rs
@@ -60,9 +60,9 @@ impl<'context> SourceUnitScope<'context> {
                     MlirType::string(self.melior, solx_utils::DataLocation::Memory)
                 }
                 LiteralKind::HexString { bytes } => MlirType::fixed_bytes(self.melior, bytes),
-                LiteralKind::Rational { .. } => unimplemented!(
-                    "MLIR type resolution is not yet implemented for rational literals"
-                ),
+                LiteralKind::Rational { .. } => {
+                    unreachable!("a rational literal folds into its integer-typed parent")
+                }
             },
             Type::String(string_type) => {
                 let location = solx_utils::DataLocation::from_slang(

--- a/tests/solidity/simple/constant_expressions/bitwise.sol
+++ b/tests/solidity/simple/constant_expressions/bitwise.sol
@@ -1,4 +1,4 @@
-//! { "ignore": true, "cases": [ {
+//! { "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {

--- a/tests/solidity/simple/constant_expressions/rational_literals.sol
+++ b/tests/solidity/simple/constant_expressions/rational_literals.sol
@@ -94,6 +94,54 @@
 //!     "expected": [
 //!         "1000000000000000000"
 //!     ]
+//! }, {
+//!     "name": "half_plus_quarter_ether",
+//!     "inputs": [
+//!         {
+//!             "method": "half_plus_quarter_ether",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "750000000000000000"
+//!     ]
+//! }, {
+//!     "name": "half_ether_plus_wei",
+//!     "inputs": [
+//!         {
+//!             "method": "half_ether_plus_wei",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "500000000000000001"
+//!     ]
+//! }, {
+//!     "name": "half_ether_below_one",
+//!     "inputs": [
+//!         {
+//!             "method": "half_ether_below_one",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1"
+//!     ]
+//! }, {
+//!     "name": "half_ether_above_wei",
+//!     "inputs": [
+//!         {
+//!             "method": "half_ether_above_wei",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1"
+//!     ]
 //! } ] }
 
 // SPDX-License-Identifier: MIT
@@ -131,5 +179,21 @@ contract Test {
 
     function scientific_large() public pure returns (uint256) {
         return 1e18;
+    }
+
+    function half_plus_quarter_ether() public pure returns (uint256) {
+        return 0.5 ether + 0.25 ether;
+    }
+
+    function half_ether_plus_wei() public pure returns (uint256) {
+        return 0.5 ether + 1 wei;
+    }
+
+    function half_ether_below_one() public pure returns (bool) {
+        return 0.5 ether < 1 ether;
+    }
+
+    function half_ether_above_wei() public pure returns (bool) {
+        return 0.5 ether > 1 wei;
     }
 }


### PR DESCRIPTION
Folds literal-constant expressions at their binder-computed integer values; comparisons and constant-name arithmetic stay runtime.

`cargo run-tester-slang`: 10022 → 10129 passed.