### PR TITLE
feat(slang): immutables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1723,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3035,7 +3035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4029,7 +4029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4086,7 +4086,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4567,7 +4567,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 dependencies = [
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4611,12 +4611,12 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 dependencies = [
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=4f3fe84b6179a9370f711804247905ca819e421d#4f3fe84b6179a9370f711804247905ca819e421d"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -5000,7 +5000,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5135,7 +5134,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5144,7 +5143,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5775,7 +5774,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "4f3fe84b6179a9370f711804247905ca819e421d"
+rev = "8948967bda8badbc225339b4b97764d13688f2c6"

--- a/solx-core/src/project/contract/mod.rs
+++ b/solx-core/src/project/contract/mod.rs
@@ -316,7 +316,6 @@ impl Contract {
                     solc_version.expect("Always exists").default,
                 );
 
-                // Deploy: accumulate dependencies from assembly before it is consumed
                 let mut accumulated_dependencies = solx_utils::Dependencies::new(
                     code_identifier.as_str(),
                     code.dependencies.runtime.clone(),
@@ -516,10 +515,6 @@ impl Contract {
                 };
 
                 let melior = solx_mlir::Context::create_melior_context();
-                // The deploy code of a failed runtime build still compiles, against a
-                // placeholder offset, so its own errors surface.
-                // TODO: support user-declared immutables, whose offsets the runtime build
-                // records per name beside the library address tag.
                 let immutables = match code_segment {
                     solx_utils::CodeSegment::Deploy => immutables.unwrap_or_else(|| {
                         BTreeMap::from([(

--- a/solx-mlir/src/context/contract.rs
+++ b/solx-mlir/src/context/contract.rs
@@ -1,5 +1,6 @@
 //!
-//! The Contract declaration entity: emits `sol.contract` and its `sol.state_var` members.
+//! The Contract declaration entity: emits `sol.contract` and its `sol.state_var` and
+//! `sol.immutable` members.
 //!
 
 use melior::ir::attribute::IntegerAttribute;
@@ -13,6 +14,7 @@ use crate::Context;
 use crate::ContractKind;
 use crate::Type;
 use crate::ods::sol::ContractOperation;
+use crate::ods::sol::ImmutableOperation;
 use crate::ods::sol::StateVarOperation;
 
 /// A `sol.contract` declaration and the insertion point for its `sol.state_var` members.
@@ -66,6 +68,23 @@ impl<'context> Contract<'context> {
                     byte_offset.into(),
                 ))
                 .transient(transient);
+            ()
+        );
+    }
+
+    /// Emits a `sol.immutable @name` member of `element_type`.
+    pub fn declare_immutable(
+        self,
+        name: &str,
+        element_type: Type<'context>,
+        context: &Context<'context>,
+    ) {
+        mlir_op!(
+            context,
+            self.body,
+            ImmutableOperation
+                .sym_name(StringAttribute::new(context.melior, name))
+                .r#type(TypeAttribute::new(element_type.into_mlir()));
             ()
         );
     }

--- a/solx-mlir/src/context/function/dispatch.rs
+++ b/solx-mlir/src/context/function/dispatch.rs
@@ -9,7 +9,7 @@ use slang_solidity_v2::ast::NodeId;
 use crate::FunctionKind;
 
 /// The internal dispatch attribute a `sol.func` carries, if any.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FunctionDispatch {
     /// The identifier an internal function pointer dispatches to; never zero, which the dialect
     /// reserves for the null function pointer, since slang numbers nodes from one.

--- a/solx-mlir/src/context/function/entry.rs
+++ b/solx-mlir/src/context/function/entry.rs
@@ -1,0 +1,23 @@
+//!
+//! A defined `sol.func`'s entry block paired with its declared dispatch.
+//!
+
+use crate::Block;
+use crate::FunctionDispatch;
+
+/// A defined `sol.func`'s entry block, paired with the dispatch its declaration carries, so the
+/// body's lowering never restates it.
+#[derive(Clone, Copy)]
+pub struct FunctionEntry<'context> {
+    /// The entry block the function body is emitted into.
+    pub block: Block<'context>,
+    /// The dispatch the `sol.func` was declared with.
+    pub dispatch: FunctionDispatch,
+}
+
+impl<'context> FunctionEntry<'context> {
+    /// Pairs a defined function's entry block with its declared dispatch.
+    pub fn new(block: Block<'context>, dispatch: FunctionDispatch) -> Self {
+        Self { block, dispatch }
+    }
+}

--- a/solx-mlir/src/context/function/mod.rs
+++ b/solx-mlir/src/context/function/mod.rs
@@ -3,6 +3,7 @@
 //!
 
 pub mod dispatch;
+pub mod entry;
 
 use melior::ir::Block as MlirBlock;
 use melior::ir::Region;
@@ -16,6 +17,7 @@ use melior::ir::r#type::IntegerType;
 use crate::Block;
 use crate::Context;
 use crate::FunctionDispatch;
+use crate::FunctionEntry;
 use crate::FunctionKind;
 use crate::FunctionType;
 use crate::StateMutability;
@@ -52,8 +54,8 @@ impl<'context> Function<'context> {
     }
 
     /// Emits this function's `sol.func` definition with an entry block whose arguments carry the
-    /// parameter types, returned for the body. An original function type is attached for
-    /// selector-dispatched and constructor functions.
+    /// parameter types, returned for the body together with the declared dispatch. An original
+    /// function type is attached for selector-dispatched and constructor functions.
     pub fn define(
         &self,
         selector: Option<u32>,
@@ -61,7 +63,7 @@ impl<'context> Function<'context> {
         state_mutability: StateMutability,
         context: &Context<'context>,
         contract_body: Block<'context>,
-    ) -> Block<'context> {
+    ) -> FunctionEntry<'context> {
         let parameters = self
             .function_type
             .parameters
@@ -106,12 +108,15 @@ impl<'context> Function<'context> {
                 operation_builder.orig_fn_type(TypeAttribute::new(function_type.into()));
         }
         let operation = contract_body.append_operation(operation_builder.build().into());
-        Block::from(
-            operation
-                .region(0)
-                .expect("func has one region")
-                .first_block()
-                .expect("func body has entry block"),
+        FunctionEntry::new(
+            Block::from(
+                operation
+                    .region(0)
+                    .expect("func has one region")
+                    .first_block()
+                    .expect("func body has entry block"),
+            ),
+            dispatch,
         )
     }
 

--- a/solx-mlir/src/ir/mod.rs
+++ b/solx-mlir/src/ir/mod.rs
@@ -160,6 +160,9 @@ sol_ops! {
     Value::object_code(object_name: str) -> value {
         ObjectCodeOperation.obj_name(str_attr(object_name)).out(memory())
     }
+    Value::load_immutable(symbol: str, result_type: ty) -> value {
+        LoadImmutableOperation._name(symbol_attr(symbol)).val(result_type)
+    }
     Value::library_address(object_name: str) -> value {
         LibAddrOperation._name(str_attr(object_name)).val(address())
     }

--- a/solx-mlir/src/lib.rs
+++ b/solx-mlir/src/lib.rs
@@ -26,6 +26,7 @@ pub use self::context::contract::Contract;
 pub use self::context::environment::Environment;
 pub use self::context::function::Function;
 pub use self::context::function::dispatch::FunctionDispatch;
+pub use self::context::function::entry::FunctionEntry;
 pub use self::dialect::Dialect;
 pub use self::ir::attributes::CmpPredicate;
 pub use self::ir::attributes::ContractKind;

--- a/solx-mlir/src/lib.rs
+++ b/solx-mlir/src/lib.rs
@@ -5,6 +5,7 @@
 //! crates to emit Sol dialect operations without the raw `melior` API.
 //!
 
+#![allow(clippy::too_many_arguments)]
 // `sol_ops!` expands through `macro_rules!` recursion, one frame per declaration; full Sol dialect
 // coverage exceeds the default limit of 128.
 #![recursion_limit = "256"]

--- a/solx-mlir/tests/lit/getter.sol
+++ b/solx-mlir/tests/lit/getter.sol
@@ -21,6 +21,10 @@
 // CHECK:   %[[OV:.*]] = sol.load %[[OP]] : !sol.ptr<!sol.address, Storage>, !sol.address
 // CHECK:   sol.return %[[OV]] : !sol.address
 
+// CHECK: sol.func @{{.*price.*}}() -> ui256 attributes {{.*}}selector = -1607093762 : i32
+// CHECK:   %[[IV:.*]] = sol.load_immutable @{{.*price.*}} : ui256
+// CHECK:   sol.return %[[IV]] : ui256
+
 // CHECK: sol.func @{{.*data.*}}() -> !sol.string<Memory> attributes {{.*}}selector = 1943314746 : i32
 // CHECK:   %[[P:.*]] = sol.addr_of @{{.*data.*}} : !sol.string<Storage>
 // CHECK:   %[[C:.*]] = sol.data_loc_cast %[[P]] : !sol.string<Storage>, !sol.string<Memory>
@@ -47,6 +51,10 @@ contract ConstantKeccak {
 contract Elementary {
     uint256 public value;
     address public owner;
+}
+
+contract ImmutablePrice {
+    uint256 public immutable price;
 }
 
 contract Reference {

--- a/solx-mlir/tests/lit/immutable.sol
+++ b/solx-mlir/tests/lit/immutable.sol
@@ -1,0 +1,30 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.immutable @{{.*x.*}} : ui256
+// CHECK: sol.state_var @{{.*y.*}} slot 0 offset 0 : ui256
+
+// CHECK: sol.func @{{.*}}(%arg0: ui256) attributes {{.*}}kind = #{{.*}}Constructor
+// CHECK:   %[[XW:.*]] = sol.addr_of @{{.*x.*}} : !sol.ptr<ui256, Immutable>
+// CHECK:   sol.store %{{.*}}, %[[XW]] : ui256, !sol.ptr<ui256, Immutable>
+// CHECK:   %[[XR:.*]] = sol.addr_of @{{.*x.*}} : !sol.ptr<ui256, Immutable>
+// CHECK:   %[[XV:.*]] = sol.load %[[XR]] : !sol.ptr<ui256, Immutable>, ui256
+// CHECK:   sol.store %{{.*}}, %{{.*}} : ui256, !sol.ptr<ui256, Storage>
+
+// CHECK: sol.func @{{.*get.*}}() -> ui256 attributes {{.*}}selector = 1833756220 : i32
+// CHECK:   %[[V:.*]] = sol.load_immutable @{{.*x.*}} : ui256
+// CHECK:   sol.return %[[V]] : ui256
+
+contract Immutable {
+    uint256 immutable x;
+    uint256 y;
+
+    constructor(uint256 seed) {
+        x = seed;
+        y = x + 1;
+    }
+
+    function get() public view returns (uint256) {
+        return x;
+    }
+}

--- a/solx-mlir/tests/lit/immutable_initializer.sol
+++ b/solx-mlir/tests/lit/immutable_initializer.sol
@@ -1,0 +1,23 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+
+// solc's print-init drops declaration-site immutable initializers while its legacy pipeline
+// emits them, so solx follows legacy and this is solx-only.
+
+// CHECK: sol.immutable @{{.*x.*}} : ui256
+
+// CHECK: sol.func @{{.*}}() attributes {{.*}}kind = #{{.*}}Constructor
+// CHECK:   %[[XP:.*]] = sol.addr_of @{{.*x.*}} : !sol.ptr<ui256, Immutable>
+// CHECK:   sol.constant 42 : ui8
+// CHECK:   sol.store %{{.*}}, %[[XP]] : ui256, !sol.ptr<ui256, Immutable>
+
+// CHECK: sol.func @{{.*get.*}}() -> ui256 attributes {{.*}}selector = 1833756220 : i32
+// CHECK:   %[[V:.*]] = sol.load_immutable @{{.*x.*}} : ui256
+// CHECK:   sol.return %[[V]] : ui256
+
+contract Initialized {
+    uint256 immutable x = 42;
+
+    function get() public view returns (uint256) {
+        return x;
+    }
+}

--- a/solx-slang/src/contract/function/expression/identifier.rs
+++ b/solx-slang/src/contract/function/expression/identifier.rs
@@ -7,15 +7,19 @@ use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::Identifier;
 use slang_solidity_v2::ast::StateVariableMutability;
 
+use solx_mlir::FunctionDispatch;
+use solx_mlir::FunctionKind;
 use solx_mlir::Place;
 use solx_mlir::Type as MlirType;
 use solx_mlir::Value;
 
 use crate::contract::object::Object;
 use crate::scope::function::FunctionScope;
+use crate::scope::source_unit::SourceUnitScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// A constant folds to its initializer; a bare function name materialises its internal pointer
+    /// A constant folds to its initializer; an immutable outside the constructor loads its linked
+    /// value (`sol.load_immutable`); a bare function name materialises its internal pointer
     /// (`sol.func_constant`), defining the function in this module if absent; a library name is its
     /// linked address (`sol.lib_addr`); every other identifier loads from its place.
     pub fn identifier(&mut self, node: &Identifier) -> Value<'context> {
@@ -24,15 +28,30 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 self.expression(&constant.value().expect("constant has an initializer"))
             }
             Some(Definition::StateVariable(state_variable))
-                if matches!(
-                    state_variable.attributes().mutability(),
-                    StateVariableMutability::Constant
-                ) =>
+                if let StateVariableMutability::Constant =
+                    state_variable.attributes().mutability() =>
             {
                 self.expression(
                     &state_variable
                         .value()
                         .expect("a constant state variable is initialized"),
+                )
+            }
+            Some(Definition::StateVariable(state_variable))
+                if let StateVariableMutability::Immutable =
+                    state_variable.attributes().mutability()
+                    && self.dispatch != FunctionDispatch::Kind(FunctionKind::Constructor) =>
+            {
+                let element_type = self.resolve_type(
+                    &state_variable
+                        .get_type()
+                        .expect("binder types every state variable"),
+                    None,
+                );
+                Value::load_immutable(
+                    &SourceUnitScope::state_variable_symbol(&state_variable),
+                    element_type,
+                    self,
                 )
             }
             Some(Definition::Function(function)) => {
@@ -57,14 +76,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
     pub fn identifier_place(&mut self, node: &Identifier) -> (Place<'context>, MlirType<'context>) {
         match node.resolve_to_definition() {
             Some(Definition::StateVariable(state_variable)) => {
-                let slot_name = self
-                    .contract
-                    .storage_layout
-                    .get(&state_variable.node_id())
-                    .expect("state variable is registered in the storage layout")
-                    .name
-                    .clone();
-                self.state_variable_place(&state_variable, &slot_name)
+                self.state_variable_place(&state_variable)
             }
             Some(Definition::Variable(_) | Definition::Parameter(_)) => {
                 self.environment.variable_with_type(node.name())

--- a/solx-slang/src/contract/function/mod.rs
+++ b/solx-slang/src/contract/function/mod.rs
@@ -37,10 +37,11 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             _ => None,
         };
         let signature = self.source_unit.function_signature(function);
+        let dispatch = FunctionDispatch::from(function);
         let state_mutability = StateMutability::from(function.attributes().mutability());
         let entry = signature.define(
             selector,
-            FunctionDispatch::from(function),
+            dispatch,
             state_mutability,
             self,
             self.contract.body,
@@ -49,7 +50,7 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             parameters,
             results,
         } = signature.function_type;
-        self.function(entry, results, |scope| {
+        self.function(entry, dispatch, results, |scope| {
             for (index, parameter) in function.parameters().iter().enumerate() {
                 let Some(identifier) = parameter.name() else {
                     continue;
@@ -115,10 +116,15 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             self,
             self.contract.body,
         );
-        self.function(entry, Vec::new(), |scope| {
-            scope.state_variable_initializers();
-            scope.current_block().r#return(&[], scope);
-        });
+        self.function(
+            entry,
+            FunctionDispatch::Kind(MlirFunctionKind::Constructor),
+            Vec::new(),
+            |scope| {
+                scope.state_variable_initializers();
+                scope.current_block().r#return(&[], scope);
+            },
+        );
     }
 }
 

--- a/solx-slang/src/contract/function/mod.rs
+++ b/solx-slang/src/contract/function/mod.rs
@@ -50,13 +50,13 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             parameters,
             results,
         } = signature.function_type;
-        self.function(entry, dispatch, results, |scope| {
+        self.function(entry, results, |scope| {
             for (index, parameter) in function.parameters().iter().enumerate() {
                 let Some(identifier) = parameter.name() else {
                     continue;
                 };
                 scope.define_local(identifier.name(), parameters[index], |_scope| {
-                    entry.argument(index)
+                    entry.block.argument(index)
                 });
             }
 
@@ -116,15 +116,10 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
             self,
             self.contract.body,
         );
-        self.function(
-            entry,
-            FunctionDispatch::Kind(MlirFunctionKind::Constructor),
-            Vec::new(),
-            |scope| {
-                scope.state_variable_initializers();
-                scope.current_block().r#return(&[], scope);
-            },
-        );
+        self.function(entry, Vec::new(), |scope| {
+            scope.state_variable_initializers();
+            scope.current_block().r#return(&[], scope);
+        });
     }
 }
 

--- a/solx-slang/src/contract/getter/mod.rs
+++ b/solx-slang/src/contract/getter/mod.rs
@@ -130,16 +130,11 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     self,
                     self.contract.body,
                 );
-                self.function(
-                    entry,
-                    FunctionDispatch::Getter,
-                    signature.function_type.results,
-                    |scope| {
-                        let result_type = scope.return_types[0];
-                        let value = scope.converted(&initializer, result_type);
-                        scope.current_block().r#return(&[value], scope);
-                    },
-                );
+                self.function(entry, signature.function_type.results, |scope| {
+                    let result_type = scope.return_types[0];
+                    let value = scope.converted(&initializer, result_type);
+                    scope.current_block().r#return(&[value], scope);
+                });
             }
             StateVariableMutability::Mutable | StateVariableMutability::Transient => {
                 let getter = Getter::new(state_variable, self.source_unit);
@@ -150,17 +145,12 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     self,
                     self.contract.body,
                 );
-                self.function(
-                    entry,
-                    FunctionDispatch::Getter,
-                    signature.function_type.results,
-                    |scope| {
-                        let (place, _) = scope.state_variable_place(state_variable);
-                        let values =
-                            getter.returned_values(place, &scope.return_types, entry, scope);
-                        scope.current_block().r#return(&values, scope);
-                    },
-                );
+                self.function(entry, signature.function_type.results, |scope| {
+                    let (place, _) = scope.state_variable_place(state_variable);
+                    let values =
+                        getter.returned_values(place, &scope.return_types, entry.block, scope);
+                    scope.current_block().r#return(&values, scope);
+                });
             }
             StateVariableMutability::Immutable => {
                 let entry = signature.define(
@@ -170,27 +160,22 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     self,
                     self.contract.body,
                 );
-                self.function(
-                    entry,
-                    FunctionDispatch::Getter,
-                    signature.function_type.results,
-                    |scope| {
-                        let result_type = scope.return_types[0];
-                        let element_type = scope.resolve_type(
-                            &state_variable
-                                .get_type()
-                                .expect("binder types every state variable"),
-                            None,
-                        );
-                        let value = Value::load_immutable(
-                            &SourceUnitScope::state_variable_symbol(state_variable),
-                            element_type,
-                            scope,
-                        )
-                        .convert(result_type, scope);
-                        scope.current_block().r#return(&[value], scope);
-                    },
-                );
+                self.function(entry, signature.function_type.results, |scope| {
+                    let result_type = scope.return_types[0];
+                    let element_type = scope.resolve_type(
+                        &state_variable
+                            .get_type()
+                            .expect("binder types every state variable"),
+                        None,
+                    );
+                    let value = Value::load_immutable(
+                        &SourceUnitScope::state_variable_symbol(state_variable),
+                        element_type,
+                        scope,
+                    )
+                    .convert(result_type, scope);
+                    scope.current_block().r#return(&[value], scope);
+                });
             }
         }
     }

--- a/solx-slang/src/contract/getter/mod.rs
+++ b/solx-slang/src/contract/getter/mod.rs
@@ -106,7 +106,7 @@ impl<'context> Getter<'context> {
 impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
     /// Emits the `sol.func` a `public` state variable declares, dispatched by its ABI selector
     /// with slang's getter type as its signature. A constant folds its initializer; a mutable
-    /// variable reads its storage slot.
+    /// variable reads its storage slot; an immutable loads its linked value.
     pub fn state_variable_getter(&mut self, state_variable: &StateVariableDefinition) {
         let selector = state_variable
             .compute_selector()
@@ -130,19 +130,18 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     self,
                     self.contract.body,
                 );
-                self.function(entry, signature.function_type.results, |scope| {
-                    let result_type = scope.return_types[0];
-                    let value = scope.converted(&initializer, result_type);
-                    scope.current_block().r#return(&[value], scope);
-                });
+                self.function(
+                    entry,
+                    FunctionDispatch::Getter,
+                    signature.function_type.results,
+                    |scope| {
+                        let result_type = scope.return_types[0];
+                        let value = scope.converted(&initializer, result_type);
+                        scope.current_block().r#return(&[value], scope);
+                    },
+                );
             }
             StateVariableMutability::Mutable | StateVariableMutability::Transient => {
-                let slot_name = self
-                    .storage_layout
-                    .get(&state_variable.node_id())
-                    .expect("slang lays out every state variable")
-                    .name
-                    .clone();
                 let getter = Getter::new(state_variable, self.source_unit);
                 let entry = signature.define(
                     Some(selector),
@@ -151,14 +150,47 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
                     self,
                     self.contract.body,
                 );
-                self.function(entry, signature.function_type.results, |scope| {
-                    let (place, _) = scope.state_variable_place(state_variable, &slot_name);
-                    let values = getter.returned_values(place, &scope.return_types, entry, scope);
-                    scope.current_block().r#return(&values, scope);
-                });
+                self.function(
+                    entry,
+                    FunctionDispatch::Getter,
+                    signature.function_type.results,
+                    |scope| {
+                        let (place, _) = scope.state_variable_place(state_variable);
+                        let values =
+                            getter.returned_values(place, &scope.return_types, entry, scope);
+                        scope.current_block().r#return(&values, scope);
+                    },
+                );
             }
             StateVariableMutability::Immutable => {
-                unimplemented!("getter for a public immutable state variable")
+                let entry = signature.define(
+                    Some(selector),
+                    FunctionDispatch::Getter,
+                    StateMutability::View,
+                    self,
+                    self.contract.body,
+                );
+                self.function(
+                    entry,
+                    FunctionDispatch::Getter,
+                    signature.function_type.results,
+                    |scope| {
+                        let result_type = scope.return_types[0];
+                        let element_type = scope.resolve_type(
+                            &state_variable
+                                .get_type()
+                                .expect("binder types every state variable"),
+                            None,
+                        );
+                        let value = Value::load_immutable(
+                            &SourceUnitScope::state_variable_symbol(state_variable),
+                            element_type,
+                            scope,
+                        )
+                        .convert(result_type, scope);
+                        scope.current_block().r#return(&[value], scope);
+                    },
+                );
             }
         }
     }

--- a/solx-slang/src/contract/mod.rs
+++ b/solx-slang/src/contract/mod.rs
@@ -46,26 +46,45 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
     /// the functions, and the getters.
     fn members(&mut self, object: &Object) {
         for state_variable in self.state_variables.iter() {
-            let Some(slot) = self.storage_layout.get(&state_variable.node_id()) else {
-                continue;
-            };
-            let element_type = self.source_unit.resolve(
-                &state_variable
-                    .get_type()
-                    .expect("binder types every state variable"),
-                None,
-            );
-            self.contract.declare_state_var(
-                &slot.name,
-                element_type,
-                slot.slot,
-                slot.byte_offset,
-                matches!(
-                    state_variable.attributes().mutability(),
-                    StateVariableMutability::Transient
-                ),
-                self,
-            );
+            match state_variable.attributes().mutability() {
+                StateVariableMutability::Mutable | StateVariableMutability::Transient => {
+                    let slot = self
+                        .storage_layout
+                        .get(&state_variable.node_id())
+                        .expect("slang lays out every state variable");
+                    let element_type = self.source_unit.resolve(
+                        &state_variable
+                            .get_type()
+                            .expect("binder types every state variable"),
+                        None,
+                    );
+                    self.contract.declare_state_var(
+                        &SourceUnitScope::state_variable_symbol(state_variable),
+                        element_type,
+                        slot.slot,
+                        slot.byte_offset,
+                        matches!(
+                            state_variable.attributes().mutability(),
+                            StateVariableMutability::Transient
+                        ),
+                        self,
+                    );
+                }
+                StateVariableMutability::Immutable => {
+                    let element_type = self.source_unit.resolve(
+                        &state_variable
+                            .get_type()
+                            .expect("binder types every state variable"),
+                        None,
+                    );
+                    self.contract.declare_immutable(
+                        &SourceUnitScope::state_variable_symbol(state_variable),
+                        element_type,
+                        self,
+                    );
+                }
+                StateVariableMutability::Constant => {}
+            }
         }
         if let Object::Contract(node) = object {
             self.constructor(node);

--- a/solx-slang/src/contract/state_variable.rs
+++ b/solx-slang/src/contract/state_variable.rs
@@ -1,41 +1,38 @@
 //!
-//! State variable emission: the storage place a declaration resolves to and the inline
-//! initializers the constructor runs.
+//! State variable emission: the place a declaration resolves to and the inline initializers the
+//! constructor runs.
 //!
 
 use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::StateVariableDefinition;
+use slang_solidity_v2::ast::StateVariableMutability;
 
 use solx_mlir::Place;
 use solx_mlir::Type as MlirType;
 use solx_utils::DataLocation;
 
 use crate::scope::function::FunctionScope;
+use crate::scope::source_unit::SourceUnitScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
     /// Emits every state variable's inline initializer (`T x = <expr>;`) in source order as the
-    /// constructor prologue, storing each into its storage slot. Reference-typed slots take a
-    /// `sol.copy`; value-typed slots convert to the declared element type and `sol.store`.
+    /// constructor prologue, storing each into its place. Reference-typed slots take a
+    /// `sol.copy`; value-typed places convert to the declared element type and `sol.store`.
     pub fn state_variable_initializers(&mut self) {
-        let initializers: Vec<(StateVariableDefinition, String, Expression)> = self
+        let initializers: Vec<(StateVariableDefinition, Expression)> = self
             .contract
             .state_variables
             .iter()
-            .filter_map(|state_variable| {
-                Some((
-                    state_variable.clone(),
-                    self.contract
-                        .storage_layout
-                        .get(&state_variable.node_id())?
-                        .name
-                        .clone(),
-                    state_variable.value()?,
-                ))
+            .filter(|state_variable| {
+                matches!(
+                    state_variable.attributes().mutability(),
+                    StateVariableMutability::Mutable | StateVariableMutability::Immutable
+                )
             })
+            .filter_map(|state_variable| Some((state_variable.clone(), state_variable.value()?)))
             .collect();
-        for (state_variable, slot_name, initializer) in initializers {
-            let (storage_ref, element_type) =
-                self.state_variable_place(&state_variable, &slot_name);
+        for (state_variable, initializer) in initializers {
+            let (storage_ref, element_type) = self.state_variable_place(&state_variable);
             if storage_ref.r#type() == element_type {
                 storage_ref.copy_from(self.expression(&initializer), self);
             } else {
@@ -44,13 +41,12 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         }
     }
 
-    /// The `sol.addr_of` place of the state variable's storage slot together with its element MLIR
-    /// type, following the `Sol_GepOp` rule that a reference-typed element in storage is its own
-    /// address.
+    /// The `sol.addr_of` place of the state variable's storage slot or creation cell together with
+    /// its element MLIR type, following the `Sol_GepOp` rule that a reference-typed element in
+    /// storage is its own address.
     pub fn state_variable_place(
         &mut self,
         state_variable: &StateVariableDefinition,
-        slot_name: &str,
     ) -> (Place<'context>, MlirType<'context>) {
         let declared_type = state_variable
             .get_type()
@@ -58,7 +54,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
         let element_type = self.resolve_type(&declared_type, None);
         (
             Place::addr_of(
-                slot_name,
+                &SourceUnitScope::state_variable_symbol(state_variable),
                 self.pointer_type(
                     &declared_type,
                     element_type,
@@ -67,6 +63,17 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 self,
             ),
             element_type,
+        )
+    }
+}
+
+impl<'context> SourceUnitScope<'context> {
+    /// The state variable's symbol: its name qualified by the node id, since names alone collide.
+    pub fn state_variable_symbol(state_variable: &StateVariableDefinition) -> String {
+        format!(
+            "{}_{}",
+            state_variable.name().name(),
+            state_variable.node_id(),
         )
     }
 }

--- a/solx-slang/src/contract/storage_slot.rs
+++ b/solx-slang/src/contract/storage_slot.rs
@@ -8,9 +8,6 @@ use slang_solidity_v2::abi::StorageItem;
 /// Storage location of a state variable in contract storage.
 #[derive(Debug, Clone)]
 pub struct StorageSlot {
-    /// MLIR symbol name, formatted as `{label}_{node_id}`. The slang AST node
-    /// id disambiguates like-named variables across inherited contracts.
-    pub name: String,
     /// 256-bit storage slot index.
     pub slot: U256,
     /// Byte offset within the slot. Non-zero only for variables packed
@@ -21,7 +18,6 @@ pub struct StorageSlot {
 impl From<&StorageItem> for StorageSlot {
     fn from(item: &StorageItem) -> Self {
         Self {
-            name: format!("{}_{}", item.label(), item.node_id()),
             slot: item.slot(),
             byte_offset: item.offset() as u32,
         }

--- a/solx-slang/src/lib.rs
+++ b/solx-slang/src/lib.rs
@@ -5,6 +5,8 @@
 //! Each node's lowering lives in the file named for it at its nesting depth.
 //!
 
+#![allow(clippy::too_many_arguments)]
+
 pub(crate) mod contract;
 pub(crate) mod scope;
 pub(crate) mod slang;

--- a/solx-slang/src/scope/contract.rs
+++ b/solx-slang/src/scope/contract.rs
@@ -10,10 +10,9 @@ use std::ops::Deref;
 use slang_solidity_v2::ast::NodeId;
 use slang_solidity_v2::ast::StateVariableDefinition;
 
-use solx_mlir::Block;
 use solx_mlir::Context;
 use solx_mlir::Contract;
-use solx_mlir::FunctionDispatch;
+use solx_mlir::FunctionEntry;
 use solx_mlir::Type as MlirType;
 
 use crate::contract::object::Object;
@@ -55,18 +54,17 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
         }
     }
 
-    /// Opens the function scope around `emit`: the emitted function's dispatch, a fresh variable
+    /// Opens the function scope around `emit`: the entry's declared dispatch, a fresh variable
     /// environment, the declared return types a `return` converts to, and checked arithmetic, with
-    /// the MLIR cursor on `entry` for the body's duration.
+    /// the MLIR cursor on the entry block for the body's duration.
     pub fn function(
         &mut self,
-        entry: Block<'context>,
-        dispatch: FunctionDispatch,
+        entry: FunctionEntry<'context>,
         return_types: Vec<MlirType<'context>>,
         emit: impl FnOnce(&mut FunctionScope<'_, '_, 'context>),
     ) {
-        let enclosing = self.source_unit.mlir.current_block.replace(entry);
-        emit(&mut FunctionScope::new(self, dispatch, return_types));
+        let enclosing = self.source_unit.mlir.current_block.replace(entry.block);
+        emit(&mut FunctionScope::new(self, entry.dispatch, return_types));
         self.source_unit.mlir.current_block = enclosing;
     }
 }

--- a/solx-slang/src/scope/contract.rs
+++ b/solx-slang/src/scope/contract.rs
@@ -13,6 +13,7 @@ use slang_solidity_v2::ast::StateVariableDefinition;
 use solx_mlir::Block;
 use solx_mlir::Context;
 use solx_mlir::Contract;
+use solx_mlir::FunctionDispatch;
 use solx_mlir::Type as MlirType;
 
 use crate::contract::object::Object;
@@ -54,17 +55,18 @@ impl<'source_unit, 'context> ContractScope<'source_unit, 'context> {
         }
     }
 
-    /// Opens the function scope around `emit`: a fresh variable environment, the declared return
-    /// types a `return` converts to, and checked arithmetic, with the MLIR cursor on `entry` for the
-    /// body's duration.
+    /// Opens the function scope around `emit`: the emitted function's dispatch, a fresh variable
+    /// environment, the declared return types a `return` converts to, and checked arithmetic, with
+    /// the MLIR cursor on `entry` for the body's duration.
     pub fn function(
         &mut self,
         entry: Block<'context>,
+        dispatch: FunctionDispatch,
         return_types: Vec<MlirType<'context>>,
         emit: impl FnOnce(&mut FunctionScope<'_, '_, 'context>),
     ) {
         let enclosing = self.source_unit.mlir.current_block.replace(entry);
-        emit(&mut FunctionScope::new(self, return_types));
+        emit(&mut FunctionScope::new(self, dispatch, return_types));
         self.source_unit.mlir.current_block = enclosing;
     }
 }

--- a/solx-slang/src/scope/function.rs
+++ b/solx-slang/src/scope/function.rs
@@ -1,7 +1,7 @@
 //!
-//! The function scope: the enclosing contract scope, the lexical variable environment, the declared
-//! return types, and the checked-arithmetic flag, together with the frame combinators every
-//! lowering threads through.
+//! The function scope: the enclosing contract scope, the dispatch of the function being emitted,
+//! the lexical variable environment, the declared return types, and the checked-arithmetic flag,
+//! together with the frame combinators every lowering threads through.
 //!
 
 use std::ops::Deref;
@@ -11,17 +11,21 @@ use slang_solidity_v2::ast::Type;
 use solx_mlir::Block;
 use solx_mlir::Context;
 use solx_mlir::Environment;
+use solx_mlir::FunctionDispatch;
 use solx_mlir::Place;
 use solx_mlir::Type as MlirType;
 use solx_mlir::Value;
 
 use crate::scope::contract::ContractScope;
 
-/// The function scope: the enclosing contract scope, the lexical variable environment, the declared
-/// return types a `return` converts to, and whether arithmetic is checked at the current position.
+/// The function scope: the enclosing contract scope, the dispatch of the `sol.func` being emitted,
+/// the lexical variable environment, the declared return types a `return` converts to, and whether
+/// arithmetic is checked at the current position.
 pub struct FunctionScope<'contract, 'source_unit, 'context> {
     /// The contract scope this function body is lowered within.
     pub contract: &'contract mut ContractScope<'source_unit, 'context>,
+    /// The dispatch of the `sol.func` being emitted.
+    pub dispatch: FunctionDispatch,
     /// The lexically scoped variable bindings.
     pub environment: Environment<'context>,
     /// The declared return types a `return` converts to.
@@ -31,13 +35,16 @@ pub struct FunctionScope<'contract, 'source_unit, 'context> {
 }
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// Opens a function scope within `contract` with the given declared return types.
+    /// Opens a function scope within `contract` for the dispatched function with the given
+    /// declared return types.
     pub fn new(
         contract: &'contract mut ContractScope<'source_unit, 'context>,
+        dispatch: FunctionDispatch,
         return_types: Vec<MlirType<'context>>,
     ) -> Self {
         Self {
             contract,
+            dispatch,
             environment: Environment::new(),
             return_types,
             checked: true,


### PR DESCRIPTION
Supports user-declared immutables: declarations, constructor writes and reads, runtime loads, getters, and declaration-site initializers. Every state variable's symbol now comes from one owner function.

`cargo run-tester-slang`: 10217 → 10323 passed.