### PR TITLE
feat: parse EVM legacy assemblies emitted as pre-serialized strings

### DIFF
--- a/solx-core/src/project/contract/ir/evmla.rs
+++ b/solx-core/src/project/contract/ir/evmla.rs
@@ -25,21 +25,18 @@ impl EVMLegacyAssembly {
         extra_metadata: Option<solx_evm_assembly::ExtraMetadata>,
     ) -> anyhow::Result<Self> {
         assembly.extra_metadata = extra_metadata.clone();
-        if let Ok(runtime_code) = assembly.runtime_code_mut() {
-            runtime_code.extra_metadata = extra_metadata;
-        }
 
-        let runtime_code_assembly = assembly
-            .runtime_code()
+        let runtime_code_identifier = format!("{full_path}.{}", solx_utils::CodeSegment::Runtime);
+        let mut runtime_code_dependencies =
+            solx_codegen_evm::Dependencies::new(runtime_code_identifier.as_str());
+        let mut runtime_code_assembly = assembly
+            .take_runtime_code(runtime_code_identifier)
             .map_err(|error| {
                 anyhow::anyhow!(
                     "EVM legacy assembly is missing runtime code for `{full_path}`: {error}"
                 )
-            })?
-            .to_owned();
-        let runtime_code_identifier = format!("{full_path}.{}", solx_utils::CodeSegment::Runtime);
-        let mut runtime_code_dependencies =
-            solx_codegen_evm::Dependencies::new(runtime_code_identifier.as_str());
+            })?;
+        runtime_code_assembly.extra_metadata = extra_metadata;
         runtime_code_assembly.accumulate_evm_dependencies(&mut runtime_code_dependencies);
         let runtime_code = Some(Box::new(Self {
             assembly: runtime_code_assembly,
@@ -49,7 +46,6 @@ impl EVMLegacyAssembly {
 
         let mut deploy_code_dependencies = solx_codegen_evm::Dependencies::new(full_path);
         assembly.accumulate_evm_dependencies(&mut deploy_code_dependencies);
-        assembly.strip_runtime_code(runtime_code_identifier);
 
         Ok(Self {
             assembly,

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -167,7 +167,7 @@ impl Project {
                     .evm
                     .as_mut()
                     .and_then(|evm| evm.method_identifiers.take());
-                let legacy_assembly = contract
+                let mut legacy_assembly = contract
                     .evm
                     .as_mut()
                     .and_then(|evm| evm.legacy_assembly.take())
@@ -203,11 +203,18 @@ impl Project {
                         .evm
                         .as_mut()
                         .and_then(|evm| evm.extra_metadata.take());
-                    legacy_assembly.as_ref().map(|legacy_assembly| {
+                    // Translation consumes the assembly, so it is only cloned when
+                    // `evm.legacyAssembly` is requested in the output.
+                    let translated_assembly = legacy_assembly.take();
+                    legacy_assembly = translated_assembly
+                        .as_ref()
+                        .filter(|_| output_legacy_assembly)
+                        .cloned();
+                    translated_assembly.map(|translated_assembly| {
                         Ok(Some(ContractIR::from(
                             ContractEVMLegacyAssembly::from_contract(
                                 name.full_path.as_str(),
-                                legacy_assembly.to_owned(),
+                                translated_assembly,
                                 extra_metadata,
                             )?,
                         )))

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -75,34 +75,25 @@ impl Assembly {
     }
 
     ///
-    /// Returns a runtime code mutable reference from the deploy code assembly.
-    ///
-    pub fn runtime_code_mut(&mut self) -> anyhow::Result<&mut Assembly> {
-        match self
-            .data
-            .as_mut()
-            .and_then(|data| data.get_mut("0"))
-            .ok_or_else(|| anyhow::anyhow!("Runtime code data not found"))?
-        {
-            Data::Assembly(assembly) => Ok(assembly),
-            Data::Hash(hash) => {
-                anyhow::bail!("Expected runtime code, found hash `{hash}`");
-            }
-            Data::Path(path) => {
-                anyhow::bail!("Expected runtime code, found path `{path}`");
-            }
-        }
-    }
-
-    ///
-    /// Replaces the nested runtime code with a path reference, dropping its instructions.
+    /// Moves the nested runtime code out, replacing it with a path reference.
     ///
     /// The deploy translation unit never enters the runtime blocks, so shipping the runtime
     /// instructions inside the deploy input is dead weight.
     ///
-    pub fn strip_runtime_code(&mut self, path: String) {
-        if let Some(data) = self.data.as_mut() {
-            data.insert("0".to_owned(), Data::Path(path));
+    pub fn take_runtime_code(&mut self, path: String) -> anyhow::Result<Assembly> {
+        match self
+            .data
+            .as_mut()
+            .and_then(|data| data.insert("0".to_owned(), Data::Path(path)))
+        {
+            Some(Data::Assembly(assembly)) => Ok(assembly),
+            Some(Data::Hash(hash)) => {
+                anyhow::bail!("Expected runtime code, found hash `{hash}`");
+            }
+            Some(Data::Path(path)) => {
+                anyhow::bail!("Expected runtime code, found path `{path}`");
+            }
+            None => anyhow::bail!("Runtime code data not found"),
         }
     }
 

--- a/solx-standard-json/src/output/contract/evm/legacy_assembly.rs
+++ b/solx-standard-json/src/output/contract/evm/legacy_assembly.rs
@@ -22,11 +22,20 @@ impl LegacyAssembly {
     ///
     /// Parses the [`LegacyAssembly::Raw`] variant into [`LegacyAssembly::Parsed`] in place.
     ///
+    /// `solc` emits the assembly as a pre-serialized JSON string, so the raw value is unwrapped
+    /// before the assembly itself is parsed; the plain object form is accepted as well.
+    ///
     pub fn materialize(&mut self) -> anyhow::Result<()> {
         if let Self::Raw(raw) = self {
-            *self = Self::Parsed(solx_utils::deserialize_from_slice::<
-                solx_evm_assembly::Assembly,
-            >(raw.get().as_bytes())?);
+            let assembly = if raw.get().starts_with('"') {
+                let json = solx_utils::deserialize_from_slice::<String>(raw.get().as_bytes())?;
+                solx_utils::deserialize_from_str::<solx_evm_assembly::Assembly>(json.as_str())?
+            } else {
+                solx_utils::deserialize_from_slice::<solx_evm_assembly::Assembly>(
+                    raw.get().as_bytes(),
+                )?
+            };
+            *self = Self::Parsed(assembly);
         }
         Ok(())
     }

--- a/solx-standard-json/src/output/contract/evm/legacy_assembly.rs
+++ b/solx-standard-json/src/output/contract/evm/legacy_assembly.rs
@@ -23,18 +23,13 @@ impl LegacyAssembly {
     /// Parses the [`LegacyAssembly::Raw`] variant into [`LegacyAssembly::Parsed`] in place.
     ///
     /// `solc` emits the assembly as a pre-serialized JSON string, so the raw value is unwrapped
-    /// before the assembly itself is parsed; the plain object form is accepted as well.
+    /// before the assembly itself is parsed.
     ///
     pub fn materialize(&mut self) -> anyhow::Result<()> {
         if let Self::Raw(raw) = self {
-            let assembly = if raw.get().starts_with('"') {
-                let json = solx_utils::deserialize_from_slice::<String>(raw.get().as_bytes())?;
-                solx_utils::deserialize_from_str::<solx_evm_assembly::Assembly>(json.as_str())?
-            } else {
-                solx_utils::deserialize_from_slice::<solx_evm_assembly::Assembly>(
-                    raw.get().as_bytes(),
-                )?
-            };
+            let json = solx_utils::deserialize_from_slice::<String>(raw.get().as_bytes())?;
+            let assembly =
+                solx_utils::deserialize_from_str::<solx_evm_assembly::Assembly>(json.as_str())?;
             *self = Self::Parsed(assembly);
         }
         Ok(())


### PR DESCRIPTION
Companion PR to https://github.com/NomicFoundation/solx-solidity/pull/174

# Claude Summary
## What

Companion to NomicFoundation/solx-solidity#174 — together they cut the legacy-pipeline main-process peak RSS on Graph Horizon from **9.56 GB to 3.94 GB** (and wall time from ~48 s to ~33 s), with byte-identical output. Three commits:

1. `refactor(core)`: translate EVM legacy assemblies without redundant copies — `try_from_solidity_output` moves each parsed assembly into translation by value (cloning only when `evm.legacyAssembly` is selected in the output), and `Assembly::take_runtime_code` replaces the clone-then-strip pair in `from_contract`. Output-invariant cleanup; on its own it does not move the RSS peak (which sits inside `solidity_compile`).
2. `feat(core)`: parse `evm.legacyAssembly` arriving as a pre-serialized JSON string. This is the consumer side of the fork-side fix: libsolc stops accumulating every contract's assembly JSON tree in its response object and hands solx compact strings instead. `materialize` unwraps the string form and still accepts the object form.
3. `chore`: pin the `solx-solidity` submodule to the tip of NomicFoundation/solx-solidity#174. **To be re-pinned to the merged `0.8.34` commit before this lands.**

## Why

Compiling Graph Horizon (240 sources, 91 Foundry test units) in legacy mode peaked at ~9.8 GB main-process RSS — first observed in the hardhat solx compile benchmarks (NomicFoundation/hardhat#8521). Per-phase RSS instrumentation showed the peak lives entirely inside the linked libsolc while it builds the standard JSON response: one nlohmann tree per contract, each recursively embedding full copies of its dependencies' assemblies, all alive until the single final dump. Details, timelines, and the vanilla-solc control runs are in solx-solidity#174.

| Horizon replay | before | after |
|---|---|---|
| legacy dump | 9.56 GB / ~48 s | **3.94 GB / ~33 s** |
| via-IR dump | 2.43 GB | 2.44 GB |

## Validation

- **Output invariance**: while the fork change was still behind a setting, a flag-toggle control (same binaries, off vs on) produced `cmp`-byte-identical standard JSON responses on both the legacy and via-IR Horizon replays — full response compared, not sampled. The final unconditional revision replays with zero structural differences against that build; the only changed bytes are CBOR metadata-hash tails embedding the fork commit hash, which change on any submodule bump by construction.
- `cargo test`: 538 passed, 0 failed, against the pinned libsolc.
- The CLI standard-JSON test with `select_all.json` covers the user-facing `evm.legacyAssembly` output (still emitted as an object — the string form is purely internal solc↔solx transport); solx-tester's EVMLA modes exercise the whole legacy pipeline.

## Notes for review

- Fork-side memory numbers, the `null`-preservation subtlety, and follow-up candidates are documented in solx-solidity#174.
