### PR TITLE
fix: report worker fatal errors per contract instead of dropping the contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.7.1"
-source = "git+https://github.com/NomicFoundation/inkwell?rev=c2ac839f8f2b67246c9676fe29e7935e95e460fb#c2ac839f8f2b67246c9676fe29e7935e95e460fb"
+source = "git+https://github.com/NomicFoundation/inkwell?rev=7098f23bbb00ba0264aa3e73595f689328322ec9#7098f23bbb00ba0264aa3e73595f689328322ec9"
 dependencies = [
  "inkwell_internals",
  "libc",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.12.0"
-source = "git+https://github.com/NomicFoundation/inkwell?rev=c2ac839f8f2b67246c9676fe29e7935e95e460fb#c2ac839f8f2b67246c9676fe29e7935e95e460fb"
+source = "git+https://github.com/NomicFoundation/inkwell?rev=7098f23bbb00ba0264aa3e73595f689328322ec9#7098f23bbb00ba0264aa3e73595f689328322ec9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2388,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.7.1"
-source = "git+https://github.com/NomicFoundation/inkwell?rev=7098f23bbb00ba0264aa3e73595f689328322ec9#7098f23bbb00ba0264aa3e73595f689328322ec9"
+source = "git+https://github.com/NomicFoundation/inkwell?rev=0081bb29a84921447fb1c9773350c52813a7fe31#0081bb29a84921447fb1c9773350c52813a7fe31"
 dependencies = [
  "inkwell_internals",
  "libc",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.12.0"
-source = "git+https://github.com/NomicFoundation/inkwell?rev=7098f23bbb00ba0264aa3e73595f689328322ec9#7098f23bbb00ba0264aa3e73595f689328322ec9"
+source = "git+https://github.com/NomicFoundation/inkwell?rev=0081bb29a84921447fb1c9773350c52813a7fe31#0081bb29a84921447fb1c9773350c52813a7fe31"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ alloy-primitives = "1.6"
 # LLVM
 [workspace.dependencies.inkwell]
 git = "https://github.com/NomicFoundation/inkwell"
-rev = "7098f23bbb00ba0264aa3e73595f689328322ec9"
+rev = "0081bb29a84921447fb1c9773350c52813a7fe31"
 default-features = false
 features = [
     "llvm21-1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ alloy-primitives = "1.6"
 # LLVM
 [workspace.dependencies.inkwell]
 git = "https://github.com/NomicFoundation/inkwell"
-rev = "c2ac839f8f2b67246c9676fe29e7935e95e460fb"
+rev = "7098f23bbb00ba0264aa3e73595f689328322ec9"
 default-features = false
 features = [
     "llvm21-1",

--- a/solx-core/src/build/mod.rs
+++ b/solx-core/src/build/mod.rs
@@ -16,8 +16,6 @@ use solx_utils::SyncLock;
 
 use solx_standard_json::CollectableError;
 
-use crate::error::Error;
-
 use self::contract::Contract;
 use self::contract::object::Object as ContractObject;
 
@@ -333,21 +331,14 @@ impl Build {
                         contract.deploy_object_result.take(),
                         contract.runtime_object_result.take(),
                     ] {
-                        match result {
-                            Some(Err(Error::StandardJson(error))) => {
-                                standard_json.errors.push(error);
-                            }
-                            // Worker deaths (e.g. LLVM fatal errors) surface as
-                            // generic errors; dropping them would emit a
-                            // successful output with the contract silently
-                            // missing.
-                            Some(Err(error)) => standard_json.errors.push(
-                                solx_standard_json::OutputError::new_error_contract(
-                                    Some(contract.name.path.as_str()),
-                                    error,
-                                ),
-                            ),
-                            Some(Ok(_)) | None => {}
+                        // Worker deaths (e.g. LLVM fatal errors) surface as
+                        // generic errors; dropping them would emit a
+                        // successful output with the contract silently
+                        // missing.
+                        if let Some(Err(error)) = result {
+                            standard_json
+                                .errors
+                                .push(error.into_standard_json(Some(contract.name.path.as_str())));
                         }
                     }
                     continue;

--- a/solx-core/src/build/mod.rs
+++ b/solx-core/src/build/mod.rs
@@ -329,15 +329,26 @@ impl Build {
                         .unwrap_or_default(),
                 );
                 if deploy_object_result.is_err() || runtime_object_result.is_err() {
-                    if let Some(Err(Error::StandardJson(error))) =
-                        contract.deploy_object_result.take()
-                    {
-                        standard_json.errors.push(error);
-                    }
-                    if let Some(Err(Error::StandardJson(error))) =
-                        contract.runtime_object_result.take()
-                    {
-                        standard_json.errors.push(error);
+                    for result in [
+                        contract.deploy_object_result.take(),
+                        contract.runtime_object_result.take(),
+                    ] {
+                        match result {
+                            Some(Err(Error::StandardJson(error))) => {
+                                standard_json.errors.push(error);
+                            }
+                            // Worker deaths (e.g. LLVM fatal errors) surface as
+                            // generic errors; dropping them would emit a
+                            // successful output with the contract silently
+                            // missing.
+                            Some(Err(error)) => standard_json.errors.push(
+                                solx_standard_json::OutputError::new_error_contract(
+                                    Some(contract.name.path.as_str()),
+                                    error,
+                                ),
+                            ),
+                            Some(Ok(_)) | None => {}
+                        }
                     }
                     continue;
                 }
@@ -406,7 +417,7 @@ impl solx_standard_json::CollectableError for Build {
                 }
                 errors
             })
-            .map(|error| error.unwrap_standard_json_ref().to_string())
+            .map(|error| error.to_string())
             .collect();
         errors.extend(
             self.messages

--- a/solx-core/src/error/mod.rs
+++ b/solx-core/src/error/mod.rs
@@ -32,7 +32,6 @@ impl Error {
             is_size_fallback,
         })
     }
-
 }
 
 impl From<anyhow::Error> for Error {

--- a/solx-core/src/error/mod.rs
+++ b/solx-core/src/error/mod.rs
@@ -33,20 +33,6 @@ impl Error {
         })
     }
 
-    ///
-    /// Unwraps the error as a `StandardJson` error reference.
-    ///
-    pub fn unwrap_standard_json_ref(&self) -> &solx_standard_json::OutputError {
-        match self {
-            Error::StandardJson(error) => error,
-            Error::Generic(error) => {
-                panic!("Expected a StandardJson error, but got a Generic error: {error}")
-            }
-            Error::StackTooDeep(error) => {
-                panic!("Expected a StandardJson error, but got a StackTooDeep error: {error}")
-            }
-        }
-    }
 }
 
 impl From<anyhow::Error> for Error {

--- a/solx-core/src/error/mod.rs
+++ b/solx-core/src/error/mod.rs
@@ -32,6 +32,19 @@ impl Error {
             is_size_fallback,
         })
     }
+
+    ///
+    /// Converts the error into a standard JSON output error.
+    ///
+    /// Non-standard-JSON variants (e.g. worker deaths on LLVM fatal errors) are wrapped
+    /// into an error attributed to the contract at `path`.
+    ///
+    pub fn into_standard_json(self, path: Option<&str>) -> solx_standard_json::OutputError {
+        match self {
+            Error::StandardJson(error) => error,
+            error => solx_standard_json::OutputError::new_error_contract(path, error),
+        }
+    }
 }
 
 impl From<anyhow::Error> for Error {

--- a/solx-core/src/process/child.rs
+++ b/solx-core/src/process/child.rs
@@ -26,6 +26,11 @@ pub fn run() -> anyhow::Result<()> {
                 .ok_or_else(|| anyhow::anyhow!("The worker received no session"))?;
 
             inkwell::support::error_handling::install_stack_error_handler(evm_stack_error_handler);
+            unsafe {
+                inkwell::support::error_handling::install_fatal_error_handler(
+                    llvm_fatal_error_handler,
+                );
+            }
 
             while let Some(job) = stdin.recv::<Job>()? {
                 solx_codegen_evm::IS_SIZE_FALLBACK.store(
@@ -65,6 +70,23 @@ pub fn run() -> anyhow::Result<()> {
         .expect("Threading error")
         .join()
         .expect("Threading error")
+}
+
+///
+/// Handles LLVM fatal errors, e.g. failed stackification of a recursive function.
+///
+/// Replies with the error over the channel so that the parent reports it per contract
+/// instead of only observing a dead worker; LLVM state is unrecoverable at this point,
+/// so the process exits without the usual LLVM shutdown. Called from LLVM's
+/// `report_fatal_error`, which aborts if the handler returns, so the process must exit here.
+///
+extern "C" fn llvm_fatal_error_handler(message: *const std::ffi::c_char) {
+    let message = unsafe { std::ffi::CStr::from_ptr(message) }.to_string_lossy();
+    let result: crate::Result<EVMOutput> = Err(Error::Generic(format!("LLVM error: {message}")));
+    std::io::stdout()
+        .send(&result)
+        .unwrap_or_else(|error| panic!("LLVM fatal error response writing error: {error}"));
+    std::process::exit(solx_utils::EXIT_CODE_SUCCESS);
 }
 
 ///

--- a/solx-core/src/process/child.rs
+++ b/solx-core/src/process/child.rs
@@ -26,11 +26,7 @@ pub fn run() -> anyhow::Result<()> {
                 .ok_or_else(|| anyhow::anyhow!("The worker received no session"))?;
 
             inkwell::support::error_handling::install_stack_error_handler(evm_stack_error_handler);
-            unsafe {
-                inkwell::support::error_handling::install_fatal_error_handler(
-                    llvm_fatal_error_handler,
-                );
-            }
+            inkwell::support::error_handling::install_fatal_error_handler(llvm_fatal_error_handler);
 
             while let Some(job) = stdin.recv::<Job>()? {
                 solx_codegen_evm::IS_SIZE_FALLBACK.store(

--- a/solx-core/src/process/pool.rs
+++ b/solx-core/src/process/pool.rs
@@ -18,9 +18,9 @@ const POISON: &str = "lock is never poisoned because worker threads do not panic
 /// The pool of persistent worker subprocesses.
 ///
 /// A worker returns to the idle list after every job it survives — a success or a per-unit
-/// compile error alike — and is retired only by a transport failure or a `StackTooDeep` reply,
-/// after which the child exits. The number of live workers never exceeds the number of
-/// dispatching threads.
+/// compile error alike — and is retired only by a transport failure or a `StackTooDeep` or
+/// LLVM-fatal reply, after which the child exits. The number of live workers never exceeds
+/// the number of dispatching threads.
 ///
 pub struct Pool {
     /// The worker executable path.
@@ -53,7 +53,7 @@ impl Pool {
     /// Compiles one translation unit on a pooled or freshly spawned worker.
     ///
     /// A worker that survives the job rejoins the pool, including after a per-unit compile error.
-    /// A transport failure or a `StackTooDeep` reply retires it instead.
+    /// A transport failure or a `StackTooDeep` or LLVM-fatal reply retires it instead.
     ///
     pub fn execute(&self, job: &Job) -> crate::Result<EVMOutput> {
         let mut worker = match self.idle.lock().expect(POISON).pop() {

--- a/solx/tests/cli/llvm_ir.rs
+++ b/solx/tests/cli/llvm_ir.rs
@@ -162,7 +162,7 @@ fn linker_error() -> anyhow::Result<()> {
 
     let result = crate::cli::execute_solx(args)?;
     result.failure().stderr(predicate::str::contains(
-        "LLVM ERROR: cannot evaluate undefined symbol 'foo'",
+        "LLVM error: cannot evaluate undefined symbol 'foo'",
     ));
 
     Ok(())

--- a/solx/tests/cli/stack_too_deep.rs
+++ b/solx/tests/cli/stack_too_deep.rs
@@ -64,6 +64,51 @@ fn stack_too_deep_llvm_suppressed() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Recursive functions cannot use the memory spill, so their stack-too-deep is
+// unrecoverable: the worker relays the LLVM fatal error, and the failure must name
+// the contract instead of dropping it from the output.
+#[cfg(feature = "solc")]
+#[test]
+fn stack_too_deep_recursive() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        crate::common::contract!("solidity/RecursiveStackTooDeep.sol"),
+        "--bin",
+        "-O1",
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+
+    result.failure().stderr(predicate::str::contains(
+        "It is recursive and has stack too deep errors.",
+    ));
+
+    Ok(())
+}
+
+#[cfg(feature = "solc")]
+#[test]
+fn stack_too_deep_recursive_standard_json() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("recursive_stack_too_deep.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+
+    result
+        .success()
+        .stdout(predicate::str::contains(
+            "It is recursive and has stack too deep errors.",
+        ))
+        .stdout(predicate::str::contains("RecursiveStackTooDeep.sol"));
+
+    Ok(())
+}
+
 // The reported spill area is underestimated under the pinned LLVM backend, so the
 // fixture compiles only through stack-too-deep retries in both the initial settings
 // and the size fallback.

--- a/solx/tests/data/contracts/solidity/RecursiveStackTooDeep.sol
+++ b/solx/tests/data/contracts/solidity/RecursiveStackTooDeep.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract RecursiveStackTooDeep {
+    function f(
+        uint256 a1, uint256 a2, uint256 a3, uint256 a4, uint256 a5, uint256 a6,
+        uint256 a7, uint256 a8, uint256 a9, uint256 a10, uint256 a11, uint256 a12,
+        uint256 a13, uint256 a14, uint256 a15, uint256 a16, uint256 a17, uint256 a18
+    ) public returns (uint256) {
+        if (a1 == 0) {
+            return a2 + a17 + a18;
+        }
+        uint256 r = f(
+            a1 - 1, a2 + 1, a3 ^ a4, a4 + a5, a5 * 2, a6 + a7, a7 ^ a8, a8 + 1,
+            a9 + a10, a10 ^ a11, a11 + a12, a12 + 1, a13 ^ a14, a14 + a15,
+            a15 + 1, a16 ^ a17, a17 + a18, a18 + a1
+        );
+        return r + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11
+            + a12 + a13 + a14 + a15 + a16 + a17 + a18;
+    }
+}

--- a/solx/tests/data/standard_json_input/recursive_stack_too_deep.json
+++ b/solx/tests/data/standard_json_input/recursive_stack_too_deep.json
@@ -1,0 +1,20 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "RecursiveStackTooDeep.sol": {
+      "content": "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n\ncontract RecursiveStackTooDeep {\n    function f(\n        uint256 a1, uint256 a2, uint256 a3, uint256 a4, uint256 a5, uint256 a6,\n        uint256 a7, uint256 a8, uint256 a9, uint256 a10, uint256 a11, uint256 a12,\n        uint256 a13, uint256 a14, uint256 a15, uint256 a16, uint256 a17, uint256 a18\n    ) public returns (uint256) {\n        if (a1 == 0) {\n            return a2 + a17 + a18;\n        }\n        uint256 r = f(\n            a1 - 1, a2 + 1, a3 ^ a4, a4 + a5, a5 * 2, a6 + a7, a7 ^ a8, a8 + 1,\n            a9 + a10, a10 ^ a11, a11 + a12, a12 + 1, a13 ^ a14, a14 + a15,\n            a15 + 1, a16 ^ a17, a17 + a18, a18 + a1\n        );\n        return r + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11\n            + a12 + a13 + a14 + a15 + a16 + a17 + a18;\n    }\n}\n"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "1"
+    },
+    "outputSelection": {
+      "*": {
+        "*": [
+          "evm.bytecode.object"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
12 of the Sourcify corpus were discovered (https://github.com/NomicFoundation/hardhat/actions/runs/32248335986/job/96067781572?pr=8538) to drop a contract due to a recursive function hitting a stack too deep, which would kill the worker, thus silently not producing a compiled contract. 

Added a generic fix for LLVM crashing with a fatal error, so these get reported properly upstream.

## Claude Summary

A worker child dying on an LLVM fatal error — e.g. failed stackification of a recursive function with stack-too-deep — previously left the affected contract **silently missing from the standard JSON output with exit code 0** and no `errors` entry, while the CLI path panicked on the same condition (`unwrap_standard_json_ref`). Downstream consumers (Hardhat, Foundry) recorded a successful build with a missing artifact.

Found by the Sourcify 0.8.34 corpus sweep (NomicFoundation/hardhat#8538) in `--compare` mode: 12 of 112,587 contracts (4 distinct projects, all with recursive functions hitting stack-too-deep) lost their deployed target contract this way while every other contract in the job was emitted normally. Reproduction: the LLVM fatal kills the codegen child; the parent maps the dead worker to `Error::Generic` (`worker.rs`), and `write_to_standard_json` only forwarded the `Error::StandardJson` variant into `errors`, dropping everything else with a `continue`.

## Changes

- The worker child installs an LLVM fatal error handler (via `install_fatal_error_handler`, already exposed by our inkwell fork) alongside the existing stack-too-deep handler: it relays the fatal message over the reply channel as a generic error and exits, so the parent receives the diagnostic instead of only observing a dead process. This also converts other backend fatals — e.g. `cannot evaluate undefined symbol` from the linker — from crash-style aborts with LLVM stack dumps into clean error reports.
- `write_to_standard_json` wraps every non-`StandardJson` per-object error into a standard JSON error naming the contract (same pattern the child already applies to in-process generic errors) instead of dropping it.
- The CLI error path stringifies all error variants instead of panicking on non-`StandardJson` ones; `unwrap_standard_json_ref` is removed together with its last caller.
- Pool doc comments updated: a worker is now also retired by an LLVM-fatal reply.

## Testing

- New fixture `RecursiveStackTooDeep.sol` (18 values live across a recursive call) with two tests:
  - `stack_too_deep_recursive_standard_json` — **fails on the previous code** (no error entry, contract silently missing) and passes now with the error naming the contract and carrying the "refactor to a non-recursive approach" guidance;
  - `stack_too_deep_recursive` — CLI mode exits nonzero with the same message.
- `cli::llvm_ir::linker_error` expectation updated: the linker fatal is now reported as `Error: LLVM error: ...` instead of a raw `LLVM ERROR:` crash dump.
- Full CLI suite green (409 tests), clippy clean.
- Verified end to end against the sweep repro inputs: the previously dropped contracts now produce a standard JSON `error` with the contract `sourceLocation`, and stderr stays free of LLVM crash diagnostics.

## Follow-up

Once released, the sweep will classify these as expected rejections (`solx-unsupported`) by matching the new diagnostic, instead of surfacing them as output mismatches. A structured error for the recursion case (instead of riding the LLVM message string) is possible later polish in solx-llvm, not required for correctness.
