### PR TITLE
docs(test-harness): record tester disable reasons; fix SSH submodule URLs and enable fixed-term-loan

### DIFF
--- a/solx-core/src/project/contract/ir/evmla.rs
+++ b/solx-core/src/project/contract/ir/evmla.rs
@@ -25,21 +25,18 @@ impl EVMLegacyAssembly {
         extra_metadata: Option<solx_evm_assembly::ExtraMetadata>,
     ) -> anyhow::Result<Self> {
         assembly.extra_metadata = extra_metadata.clone();
-        if let Ok(runtime_code) = assembly.runtime_code_mut() {
-            runtime_code.extra_metadata = extra_metadata;
-        }
 
-        let runtime_code_assembly = assembly
-            .runtime_code()
+        let runtime_code_identifier = format!("{full_path}.{}", solx_utils::CodeSegment::Runtime);
+        let mut runtime_code_dependencies =
+            solx_codegen_evm::Dependencies::new(runtime_code_identifier.as_str());
+        let mut runtime_code_assembly = assembly
+            .take_runtime_code(runtime_code_identifier)
             .map_err(|error| {
                 anyhow::anyhow!(
                     "EVM legacy assembly is missing runtime code for `{full_path}`: {error}"
                 )
-            })?
-            .to_owned();
-        let runtime_code_identifier = format!("{full_path}.{}", solx_utils::CodeSegment::Runtime);
-        let mut runtime_code_dependencies =
-            solx_codegen_evm::Dependencies::new(runtime_code_identifier.as_str());
+            })?;
+        runtime_code_assembly.extra_metadata = extra_metadata;
         runtime_code_assembly.accumulate_evm_dependencies(&mut runtime_code_dependencies);
         let runtime_code = Some(Box::new(Self {
             assembly: runtime_code_assembly,
@@ -49,7 +46,6 @@ impl EVMLegacyAssembly {
 
         let mut deploy_code_dependencies = solx_codegen_evm::Dependencies::new(full_path);
         assembly.accumulate_evm_dependencies(&mut deploy_code_dependencies);
-        assembly.strip_runtime_code(runtime_code_identifier);
 
         Ok(Self {
             assembly,

--- a/solx-core/src/project/mod.rs
+++ b/solx-core/src/project/mod.rs
@@ -167,7 +167,7 @@ impl Project {
                     .evm
                     .as_mut()
                     .and_then(|evm| evm.method_identifiers.take());
-                let legacy_assembly = contract
+                let mut legacy_assembly = contract
                     .evm
                     .as_mut()
                     .and_then(|evm| evm.legacy_assembly.take())
@@ -203,11 +203,18 @@ impl Project {
                         .evm
                         .as_mut()
                         .and_then(|evm| evm.extra_metadata.take());
-                    legacy_assembly.as_ref().map(|legacy_assembly| {
+                    // Translation consumes the assembly, so it is only cloned when
+                    // `evm.legacyAssembly` is requested in the output.
+                    let translated_assembly = legacy_assembly.take();
+                    legacy_assembly = translated_assembly
+                        .as_ref()
+                        .filter(|_| output_legacy_assembly)
+                        .cloned();
+                    translated_assembly.map(|translated_assembly| {
                         Ok(Some(ContractIR::from(
                             ContractEVMLegacyAssembly::from_contract(
                                 name.full_path.as_str(),
-                                legacy_assembly.to_owned(),
+                                translated_assembly,
                                 extra_metadata,
                             )?,
                         )))

--- a/solx-dev/foundry-tests.toml
+++ b/solx-dev/foundry-tests.toml
@@ -191,11 +191,8 @@ EVM_DISABLE_MEMORY_SAFE_ASM_CHECK = "true"
 url = "https://github.com/maple-labs/fixed-term-loan"
 commit = "8fb3675288897cb0b5748a5bbe90a12055bf9fa1"
 description = "A set of contracts to facilitate on-chain loans."
-# A nested submodule (maple-proxy-factory -> contract-test-utils) pins an SSH URL
-# (git@github.com:), so the unauthenticated CI clone fails. With an https insteadOf
-# rewrite the project compiles with solx and passes all 270 tests, so a harness-side
-# rewrite would let this project be enabled.
-disabled = true
+# A nested submodule (maple-proxy-factory -> contract-test-utils) pins an SSH URL;
+# the harness clone rewrites it to https (see GITHUB_SSH_INSTEAD_OF in utils.rs).
 
 [projects.forge-std]
 url = "https://github.com/foundry-rs/forge-std"

--- a/solx-dev/foundry-tests.toml
+++ b/solx-dev/foundry-tests.toml
@@ -191,6 +191,10 @@ EVM_DISABLE_MEMORY_SAFE_ASM_CHECK = "true"
 url = "https://github.com/maple-labs/fixed-term-loan"
 commit = "8fb3675288897cb0b5748a5bbe90a12055bf9fa1"
 description = "A set of contracts to facilitate on-chain loans."
+# A nested submodule (maple-proxy-factory -> contract-test-utils) pins an SSH URL
+# (git@github.com:), so the unauthenticated CI clone fails. With an https insteadOf
+# rewrite the project compiles with solx and passes all 270 tests, so a harness-side
+# rewrite would let this project be enabled.
 disabled = true
 
 [projects.forge-std]

--- a/solx-dev/hardhat-tests.toml
+++ b/solx-dev/hardhat-tests.toml
@@ -138,6 +138,9 @@ url = "https://github.com/antonbaliasnikov/ens-contracts"
 commit = "85ddeb9ff8def53e580a1fa70b156fe1c88775da"
 description = "The core contracts of the ENS protocol."
 build_system = "bun"
+# The fork lacks solx wiring (no USE_SOLX/SOLX in its Hardhat config) and only enables
+# solc 0.8.17/0.8.26, so the >=0.8.34 pragma pin fails HHE909. The pinned lockfile also
+# references @ensdomains/buffer@0.1.1, which has been unpublished from npm.
 disabled = true
 
 [projects.olympus]
@@ -145,6 +148,7 @@ url = "https://github.com/antonbaliasnikov/olympus-contracts"
 commit = "825a5e49ba21c3a15c2335584bb58bd3ced435e7"
 description = "A collection of contracts for Olympus DAO."
 build_system = "yarn"
+# The fork lacks solx wiring (no USE_SOLX/SOLX in its Hardhat config); solc pinned to 0.8.15.
 disabled = true
 
 [projects.synthetix]
@@ -152,4 +156,4 @@ url = "https://github.com/antonbaliasnikov/synthetix"
 commit = "1609d156708eb77025478cbcd92b98de51faf1e3"
 description = "A crypto-backed synthetic asset platform."
 build_system = "npm"
-disabled = true
+disabled = true # written in Solidity v0.4/v0.5, below the solx version floor

--- a/solx-dev/src/utils.rs
+++ b/solx-dev/src/utils.rs
@@ -130,6 +130,11 @@ pub fn command_with_json_output<T: serde::de::DeserializeOwned>(
         .map_err(|error| anyhow::anyhow!("{command:?} output parsing: {error:?}"))
 }
 
+/// Some projects pin submodules to SSH URLs (e.g. maple-labs/fixed-term-loan ->
+/// maple-proxy-factory -> contract-test-utils), which unauthenticated CI cannot fetch.
+/// Passed via `-c` so it propagates to nested submodule clones without touching global config.
+const GITHUB_SSH_INSTEAD_OF: &str = "url.https://github.com/.insteadOf=git@github.com:";
+
 ///
 /// Clones a git repository into the given directory.
 ///
@@ -169,9 +174,9 @@ pub fn clone_repository(
         let gitmodules_path = std::path::Path::new(directory).join(".gitmodules");
         if gitmodules_path.exists() {
             let mut submodule_command = Command::new("git");
+            submodule_command.args(["-C", directory]);
+            submodule_command.args(["-c", GITHUB_SSH_INSTEAD_OF]);
             submodule_command.args([
-                "-C",
-                directory,
                 "submodule",
                 "update",
                 "--init",
@@ -183,6 +188,7 @@ pub fn clone_repository(
         }
     } else {
         let mut clone_command = Command::new("git");
+        clone_command.args(["-c", GITHUB_SSH_INSTEAD_OF]);
         clone_command.arg("clone");
         clone_command.args(["--depth", "1"]);
         clone_command.arg("--recurse-submodules");

--- a/solx-evm-assembly/src/assembly/mod.rs
+++ b/solx-evm-assembly/src/assembly/mod.rs
@@ -75,34 +75,25 @@ impl Assembly {
     }
 
     ///
-    /// Returns a runtime code mutable reference from the deploy code assembly.
-    ///
-    pub fn runtime_code_mut(&mut self) -> anyhow::Result<&mut Assembly> {
-        match self
-            .data
-            .as_mut()
-            .and_then(|data| data.get_mut("0"))
-            .ok_or_else(|| anyhow::anyhow!("Runtime code data not found"))?
-        {
-            Data::Assembly(assembly) => Ok(assembly),
-            Data::Hash(hash) => {
-                anyhow::bail!("Expected runtime code, found hash `{hash}`");
-            }
-            Data::Path(path) => {
-                anyhow::bail!("Expected runtime code, found path `{path}`");
-            }
-        }
-    }
-
-    ///
-    /// Replaces the nested runtime code with a path reference, dropping its instructions.
+    /// Moves the nested runtime code out, replacing it with a path reference.
     ///
     /// The deploy translation unit never enters the runtime blocks, so shipping the runtime
     /// instructions inside the deploy input is dead weight.
     ///
-    pub fn strip_runtime_code(&mut self, path: String) {
-        if let Some(data) = self.data.as_mut() {
-            data.insert("0".to_owned(), Data::Path(path));
+    pub fn take_runtime_code(&mut self, path: String) -> anyhow::Result<Assembly> {
+        match self
+            .data
+            .as_mut()
+            .and_then(|data| data.insert("0".to_owned(), Data::Path(path)))
+        {
+            Some(Data::Assembly(assembly)) => Ok(assembly),
+            Some(Data::Hash(hash)) => {
+                anyhow::bail!("Expected runtime code, found hash `{hash}`");
+            }
+            Some(Data::Path(path)) => {
+                anyhow::bail!("Expected runtime code, found path `{path}`");
+            }
+            None => anyhow::bail!("Runtime code data not found"),
         }
     }
 

--- a/solx-standard-json/src/output/contract/evm/legacy_assembly.rs
+++ b/solx-standard-json/src/output/contract/evm/legacy_assembly.rs
@@ -22,11 +22,20 @@ impl LegacyAssembly {
     ///
     /// Parses the [`LegacyAssembly::Raw`] variant into [`LegacyAssembly::Parsed`] in place.
     ///
+    /// `solc` emits the assembly as a pre-serialized JSON string, so the raw value is unwrapped
+    /// before the assembly itself is parsed; the plain object form is accepted as well.
+    ///
     pub fn materialize(&mut self) -> anyhow::Result<()> {
         if let Self::Raw(raw) = self {
-            *self = Self::Parsed(solx_utils::deserialize_from_slice::<
-                solx_evm_assembly::Assembly,
-            >(raw.get().as_bytes())?);
+            let assembly = if raw.get().starts_with('"') {
+                let json = solx_utils::deserialize_from_slice::<String>(raw.get().as_bytes())?;
+                solx_utils::deserialize_from_str::<solx_evm_assembly::Assembly>(json.as_str())?
+            } else {
+                solx_utils::deserialize_from_slice::<solx_evm_assembly::Assembly>(
+                    raw.get().as_bytes(),
+                )?
+            };
+            *self = Self::Parsed(assembly);
         }
         Ok(())
     }


### PR DESCRIPTION
* Add disable reasons for disabled repositories in solx-tester
* Did a quickfix for the synthetix repo. 
* Will follow-up with further fixes that need more logic. 




# Claude Summary
# Record tester disable reasons; fix SSH submodule URLs and enable fixed-term-loan

The four undocumented `disabled = true` entries in the harness configs date back to the
configs' introduction (#110/#175) with no reason recorded anywhere — in git history, PR
bodies, or comments. This PR determines each reason empirically and records it, and fixes
the one that turned out not to be a solx limitation at all.

## Disable reasons (first commit)

Each project was run through the harness prep (pragma pin, `forge config --fix`,
via_ir/evm_version strip) and built with solx 0.1.7 locally:

| Project | Reason |
|---|---|
| ens-contracts (Hardhat) | Fork lacks solx wiring (no `USE_SOLX`/`SOLX` in its Hardhat config) and only enables solc 0.8.17/0.8.26, so the harness's `>=0.8.34` pragma pin fails HHE909. The pinned lockfile also references `@ensdomains/buffer@0.1.1`, which has been unpublished from npm (registry now has 0.1.0 → 0.1.3), so it is uninstallable as pinned. |
| olympus (Hardhat) | Fork lacks solx wiring; solc pinned to 0.8.15. |
| synthetix (Hardhat) | Written in Solidity v0.4/v0.5 — below the solx version floor (same class as the documented lido-core disable). |
| fixed-term-loan (Foundry) | A nested submodule pins an SSH URL, so the unauthenticated CI clone fails — see below. Not a solx limitation. |

ens-contracts and olympus need fork-side work (solx wiring plus a version lift) before they
can be enabled; synthetix cannot be.

## SSH submodule URL fix + enable fixed-term-loan (second commit)

`maple-labs/fixed-term-loan` pins `maple-proxy-factory -> contract-test-utils` to a
`git@github.com:` URL, which the harness's unauthenticated clone cannot fetch. The fix passes
`-c url.https://github.com/.insteadOf=git@github.com:` on the two submodule-touching git
invocations in `clone_repository` (the SHA-path `submodule update` and the `--recurse-submodules`
fallback). Per-process `-c` config propagates to nested submodule clones via
`GIT_CONFIG_PARAMETERS`; verified against the exact failing case at the same
`--depth 1 --recursive` shape the harness uses. Scoped per invocation — no global git config
mutation on runners or dev machines, and the main-repo fetch is unaffected (project URLs in
the configs are already https).

With the clone fixed, fixed-term-loan was its own validation: it compiles with solx 0.1.7 on
**both codegens without the memory-safe-asm escape hatch** and passes **270/270 tests on both
legs** (`--fuzz-runs 0`, `FOUNDRY_INVARIANT_RUNS=1`, seed `0xdeadbeef`), so the project is
enabled. It is a lean repo — the test suites finish in ~100 ms — so integration runtime impact
is negligible; it will appear as new rows in the Foundry benchmark reports.

## Testing

- `cargo check -p solx-dev` clean.
- Harness clone sequence replicated verbatim on a fresh clone with the rewrite: nested
  SSH-pinned submodule resolves via https, exit 0.
- fixed-term-loan: builds on legacy and viaIR without `EVM_DISABLE_MEMORY_SAFE_ASM_CHECK`;
  270 passed / 0 failed on each codegen.
- Needs a `ci:integration` run to see fixed-term-loan exercised in CI before merge.
