### PR TITLE
ci: hold arrayref at 0.3.9 instead of taking the yank bump

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,20 @@
 [advisories]
 yanked = "deny"
 
+# arrayref 0.3.5-0.3.9 -- every version satisfying our dependents' ^0.3.5
+# (blake2b_simd/blake2s_simd) and ^0.3.6 (revm-precompile) -- were yanked on
+# 2026-08-20, leaving 0.3.10 as the only resolvable version. 0.3.10 adds a
+# dependency on `proc-macro1`, a typosquat of proc-macro2 pulling in ureq and
+# rustls, which crates.io has since deleted outright rather than yanked. Its
+# src/lib.rs is byte-identical to 0.3.9's and it has no corresponding upstream
+# commit or tag, so the release carries no fix -- only the new dependency.
+# Hold at 0.3.9 and do NOT run `cargo update -p arrayref`, which cargo-deny's
+# own error message suggests. Drop this entry once a clean version ships or the
+# yanks are reverted.
+ignore = [
+    { crate = "arrayref@0.3.9", reason = "yanked to force resolution onto the compromised 0.3.10; see comment above" },
+]
+
 [licenses]
 allow = [
     "GPL-3.0-only",


### PR DESCRIPTION
## Problem

`cargo-checks` fails on `main` and on every open PR (e.g. #668):

```
error[yanked]: detected yanked crate (try `cargo update -p arrayref`)
   ┌─ Cargo.lock:28:1
28 │ arrayref 0.3.9 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
```

cargo-deny reads a live yank state, so this is unrelated to any PR's contents.

## Why the suggested fix is the wrong one

`cargo update -p arrayref` resolves to `arrayref` 0.3.10, published 2026-08-20 07:15 UTC. It should not be taken:

| Signal | Finding |
|---|---|
| `src/lib.rs` | Byte-identical to 0.3.9 — the release contains no functional change |
| New runtime dep | `[dependencies.proc-macro1] = "1.0.107"` — a typosquat of `proc-macro2` |
| `proc-macro1`'s own deps | `base64`, `rustls`, `unicode-ident`, **`ureq`** — an HTTP client and base64 inside a crate presenting as a proc-macro helper |
| `proc-macro1` on crates.io | **HTTP 403 — deleted.** crates.io deletes malware; ordinary bad releases are only yanked |
| `.cargo_vcs_info.json` | Absent from the 0.3.10 tarball — published from a directory not under version control |
| Upstream repo | `droundy/arrayref` has no commit or tag after 2024-09-14; 0.3.10 does not exist in public VCS |

The yank range is itself targeted rather than housekeeping. From the sparse index:

```
0.3.4  OK        0.3.7  yanked
0.3.5  yanked    0.3.8  yanked
0.3.6  yanked    0.3.9  yanked      0.3.10  OK  (deps: proc-macro1)
```

Our dependents require `^0.3.5` (`blake2b_simd`, `blake2s_simd`) and `^0.3.6` (`revm-precompile`). Yanking exactly 0.3.5–0.3.9 leaves 0.3.10 as the only version satisfying either constraint — consistent with a publish-token compromise that yanked the good versions to force resolution onto the payload, not with maintainer cleanup. There is no RUSTSEC advisory yet; the release is hours old.

Both paths into our tree are transitive, so there is nothing to bump at the manifest level:

- `arrayref` ← `blake2b_simd`/`blake2s_simd` ← `multihash` ← `cid` ← `ipfs-unixfs`
- `arrayref` ← `revm-precompile` ← `revm` ← `solx-tester`

## Fix

Hold at 0.3.9 and scope a `[advisories] ignore` exception to that exact crate version, so `yanked = "deny"` keeps applying to everything else.

`Cargo.lock` needs no change: it already pins 0.3.9 with a checksum, and yanked crates remain downloadable, so `cargo fetch --locked` is unaffected. That also means no `.cargo/cooldown-allowlist.toml` entry is required — unlike the RUSTSEC-driven bumps in #493 and the crossbeam-epoch fix, this one touches no lockfile.

Rejected alternatives:

- `cargo update -p arrayref` — pulls the payload.
- `yanked = "warn"` — disables the check repo-wide to solve one crate.
- `[patch]` or vendoring arrayref — heavyweight for a crate we are already safely pinned to, and would need a new `allow-git` entry.

## Verification

Run with cargo-deny 0.20.2, the version the pinned `cargo-deny-action` ships, so local and CI behaviour match:

```
$ cargo deny check --allow unmaintained --hide-inclusion-graph
advisories ok, bans ok, licenses ok, sources ok
```

Pre-existing `unnecessary-skip` / `unmatched-skip` warnings on the `[bans]` skip list (`thiserror`, `thiserror-impl`, `toml_datetime`, `toml_edit`) are unchanged by this PR and remain warnings.

Cooldown check also re-run for completeness, unaffected as expected:

```
INFO - Dependency graph passed cooldown check ✅
```

## Follow-ups

- **Revisit when upstream resolves.** Drop the `ignore` entry once a clean arrayref ships or the yanks are reverted. The inline comment says so.
- **edr is on the same version.** `edr`'s `Cargo.lock` also pins `arrayref` 0.3.9 — the safe version — and edr has no `deny.toml`, so its CI is unaffected. But `cargo update` there would land on 0.3.10, so lockfile regeneration should wait until upstream is sorted out.
- **Renovate needs no guard.** `arrayref` appears in no `Cargo.toml` and `lockFileMaintenance` is off, so the cargo manager cannot propose it; a `packageRules` pin would be dead config.
