### PR TITLE
ci: sequence warm-solc after warm-llvm

### DIFF
--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -93,6 +93,7 @@ jobs:
 
   # ── solc: standard config (test.yaml / build-and-test) ──────────────
   warm-solc:
+    needs: warm-llvm
     strategy:
       fail-fast: false
       matrix:
@@ -131,8 +132,6 @@ jobs:
 
       - name: Build toolchain
         uses: ./.github/actions/build-toolchain
-        with:
-          llvm: 'false'
 
       - name: Touch solc ccache
         if: always()


### PR DESCRIPTION
Since the slang switch (#617) the solc build requires the MLIR-enabled LLVM tree, so warm-solc now runs after warm-llvm and lets build-toolchain restore that tree from the artifact cache instead of failing on every solx-solidity bump.