### PR TITLE
fix(slang): convert operands to the types their dialect ops admit

### DIFF
--- a/solx-mlir/src/ir/type/mod.rs
+++ b/solx-mlir/src/ir/type/mod.rs
@@ -116,6 +116,20 @@ impl<'context> Type<'context> {
         })
     }
 
+    /// The type a constant of this declared type folds at. A `string`/`bytes` constant folds in
+    /// memory. A value type folds as itself.
+    pub fn folded_constant(self) -> Self {
+        if self.is_string() {
+            return Self::new(unsafe {
+                MlirType::from_raw(ffi::solxCreateStringType(
+                    mlir_sys::mlirTypeGetContext(self.inner.to_raw()),
+                    solx_utils::DataLocation::Memory as u32,
+                ))
+            });
+        }
+        self
+    }
+
     /// The `sol::ByteType` singleton (`!sol.byte`), the element a dynamic `bytes` push yields,
     /// distinct from the one-byte `bytes1`.
     pub fn byte(context: &'context melior::Context) -> Self {

--- a/solx-mlir/src/ir/value.rs
+++ b/solx-mlir/src/ir/value.rs
@@ -172,6 +172,15 @@ impl<'context> Value<'context> {
                 .address_cast(target_type, context);
         }
         if self.r#type().is_string() && target_type.is_bytes_like() {
+            let byte = Type::byte(context.melior);
+            if target_type == byte {
+                return self
+                    .dyn_bytes_to_fixedbytes(
+                        Type::fixed_bytes(context.melior, solx_utils::BYTE_LENGTH_BYTE),
+                        context,
+                    )
+                    .bytes_cast(byte, context);
+            }
             return self.dyn_bytes_to_fixedbytes(target_type, context);
         }
         if self.r#type().is_bytes_like() {

--- a/solx-mlir/tests/lit/array_string_ops.sol
+++ b/solx-mlir/tests/lit/array_string_ops.sol
@@ -43,6 +43,14 @@
 // CHECK: sol.func {{.*}}pushByteEmpty
 // CHECK:   sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.byte, Storage>
 
+// CHECK: sol.func {{.*}}pushByteStrLit
+// CHECK:   %[[PSL:.*]] = sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.byte, Storage>
+// CHECK:   sol.store %{{.*}}, %[[PSL]] : !sol.byte, !sol.ptr<!sol.byte, Storage>
+
+// CHECK: sol.func {{.*}}pushByteHexLit
+// CHECK:   %[[PHL:.*]] = sol.push %{{.*}} : !sol.string<Storage> -> !sol.ptr<!sol.byte, Storage>
+// CHECK:   sol.store %{{.*}}, %[[PHL]] : !sol.byte, !sol.ptr<!sol.byte, Storage>
+
 // CHECK: sol.func {{.*}}popLast
 // CHECK:   sol.pop %{{.*}} : !sol.array<? x ui256, Storage>
 
@@ -104,6 +112,14 @@ contract C {
 
     function pushByteEmpty() public {
         data.push();
+    }
+
+    function pushByteStrLit() public {
+        data.push() = "G";
+    }
+
+    function pushByteHexLit() public {
+        data.push() = hex"48";
     }
 
     function popLast() public {

--- a/solx-mlir/tests/lit/compound_assignment_bytes_element.sol
+++ b/solx-mlir/tests/lit/compound_assignment_bytes_element.sol
@@ -1,0 +1,50 @@
+// RUN: solx --emit-mlir=sol %s | FileCheck %s
+// RUN: solc --mlir-action=print-init %s 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*or_element.*}}
+// CHECK:   %[[OR_PTR:.*]] = sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui8, !sol.ptr<!sol.byte, Memory>
+// CHECK:   sol.load %[[OR_PTR]] : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK:   sol.or %{{.*}}, %{{.*}} : !sol.{{(fixedbytes<1>|byte)}}
+// CHECK:   sol.store %{{.*}}, %[[OR_PTR]] : !sol.byte, !sol.ptr<!sol.byte, Memory>
+
+// CHECK: sol.func @{{.*and_element.*}}
+// CHECK:   %[[AND_PTR:.*]] = sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui8, !sol.ptr<!sol.byte, Memory>
+// CHECK:   sol.load %[[AND_PTR]] : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK:   sol.and %{{.*}}, %{{.*}} : !sol.{{(fixedbytes<1>|byte)}}
+// CHECK:   sol.store %{{.*}}, %[[AND_PTR]] : !sol.byte, !sol.ptr<!sol.byte, Memory>
+
+// CHECK: sol.func @{{.*xor_element.*}}
+// CHECK:   %[[XOR_PTR:.*]] = sol.gep %{{.*}}, %{{.*}} : !sol.string<Memory>, ui8, !sol.ptr<!sol.byte, Memory>
+// CHECK:   sol.load %[[XOR_PTR]] : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK:   sol.xor %{{.*}}, %{{.*}} : !sol.{{(fixedbytes<1>|byte)}}
+// CHECK:   sol.store %{{.*}}, %[[XOR_PTR]] : !sol.byte, !sol.ptr<!sol.byte, Memory>
+
+// CHECK: sol.func @{{.*or_storage_element.*}}
+// CHECK:   %[[SPTR:.*]] = sol.gep %{{.*}}, %{{.*}} : !sol.string<Storage>, ui8, !sol.ptr<!sol.byte, Storage>
+// CHECK:   sol.load %[[SPTR]] : !sol.ptr<!sol.byte, Storage>, !sol.byte
+// CHECK:   sol.or %{{.*}}, %{{.*}} : !sol.{{(fixedbytes<1>|byte)}}
+// CHECK:   sol.store %{{.*}}, %[[SPTR]] : !sol.byte, !sol.ptr<!sol.byte, Storage>
+
+contract C {
+    bytes data;
+
+    function or_element(bytes memory a) public pure returns (bytes1) {
+        a[0] |= 0x05;
+        return a[0];
+    }
+
+    function and_element(bytes memory a) public pure returns (bytes1) {
+        a[1] &= 0xf8;
+        return a[1];
+    }
+
+    function xor_element(bytes memory a) public pure returns (bytes1) {
+        a[2] ^= 0x07;
+        return a[2];
+    }
+
+    function or_storage_element(bytes1 x) public returns (bytes1) {
+        data[0] |= x;
+        return data[0];
+    }
+}

--- a/solx-mlir/tests/lit/constant_fold_declared_type.sol
+++ b/solx-mlir/tests/lit/constant_fold_declared_type.sol
@@ -1,0 +1,26 @@
+// RUN: solx --emit-mlir=sol %constants/constant_fold_declared_type.sol | FileCheck %s
+// RUN: solc --mlir-action=print-init %constants/constant_fold_declared_type.sol 2>/dev/null | FileCheck %s
+
+// CHECK: sol.func @{{.*digits.*}}() -> !sol.fixedbytes<16>
+// CHECK:   %[[DGC:.*]] = sol.constant 64058384521018188869745042196707698022 : ui128
+// CHECK:   %[[DG:.*]] = sol.bytes_cast %[[DGC]] : ui128 to !sol.fixedbytes<16>
+// CHECK:   sol.return %[[DG]] : !sol.fixedbytes<16>
+
+// CHECK: sol.func @{{.*hexDigit.*}} -> !sol.fixedbytes<1>
+// CHECK:   %[[HDC:.*]] = sol.constant 64058384521018188869745042196707698022 : ui128
+// CHECK:   %[[HD:.*]] = sol.bytes_cast %[[HDC]] : ui128 to !sol.fixedbytes<16>
+// CHECK:   sol.fixed_bytes_index %[[HD]][%{{.*}}] : !sol.fixedbytes<16>, ui256 -> !sol.fixedbytes<1>
+
+// CHECK: sol.func @{{.*pubDigit.*}} -> !sol.fixedbytes<1>
+// CHECK:   %[[PDC:.*]] = sol.constant 64058384521018188869745006874357679430 : ui128
+// CHECK:   %[[PD:.*]] = sol.bytes_cast %[[PDC]] : ui128 to !sol.fixedbytes<16>
+// CHECK:   sol.fixed_bytes_index %[[PD]][%{{.*}}] : !sol.fixedbytes<16>, ui256 -> !sol.fixedbytes<1>
+
+// CHECK: sol.func @{{.*fileDigit.*}} -> !sol.fixedbytes<1>
+// CHECK:   %[[FDC:.*]] = sol.constant 92071172066227433993572960279997788208 : ui128
+// CHECK:   %[[FD:.*]] = sol.bytes_cast %[[FDC]] : ui128 to !sol.fixedbytes<16>
+// CHECK:   sol.fixed_bytes_index %[[FD]][%{{.*}}] : !sol.fixedbytes<16>, ui256 -> !sol.fixedbytes<1>
+
+// CHECK: sol.func @{{.*text.*}}() -> !sol.string<Memory>
+// CHECK:   %[[TX:.*]] = sol.string_lit "solx" -> !sol.string<Memory>
+// CHECK:   sol.return %[[TX]] : !sol.string<Memory>

--- a/solx-mlir/tests/lit/ecrecover.sol
+++ b/solx-mlir/tests/lit/ecrecover.sol
@@ -13,6 +13,14 @@
 // CHECK:   sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
 // CHECK:   sol.ecrecover{{.*}}: (!sol.fixedbytes<32>, ui8, !sol.fixedbytes<32>, !sol.fixedbytes<32>) -> !sol.address
 
+// CHECK: sol.func @{{.*folded.*}}
+// CHECK:   %[[MAX:.*]] = sol.constant 115792089237316195423570985008687907853269984665640564039457584007913129639935 : ui256
+// CHECK:   %[[H:.*]] = sol.bytes_cast %[[MAX]] : ui256 to !sol.fixedbytes<32>
+// CHECK:   %[[V:.*]] = sol.constant 1 : ui8
+// CHECK:   %[[R:.*]] = sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+// CHECK:   %[[S:.*]] = sol.bytes_cast %{{.*}} : ui256 to !sol.fixedbytes<32>
+// CHECK:   sol.ecrecover"(%[[H]], %[[V]], %[[R]], %[[S]]) : (!sol.fixedbytes<32>, ui8, !sol.fixedbytes<32>, !sol.fixedbytes<32>) -> !sol.address
+
 contract C {
     function variables(bytes32 h, uint8 v, bytes32 r, bytes32 s) public pure returns (address) {
         return ecrecover(h, v, r, s);
@@ -20,5 +28,9 @@ contract C {
 
     function literals() public pure returns (address) {
         return ecrecover(bytes32(uint256(1)), 27, bytes32(uint256(2)), bytes32(uint256(3)));
+    }
+
+    function folded() public pure returns (address) {
+        return ecrecover(bytes32(type(uint256).max), 1, bytes32(uint256(2)), bytes32(uint256(3)));
     }
 }

--- a/solx-mlir/tests/lit/lit.cfg.py
+++ b/solx-mlir/tests/lit/lit.cfg.py
@@ -15,6 +15,9 @@ config.environment["PATH"] = os.pathsep.join(
 )
 
 config.substitutions.append(
+    ("%constants", os.path.join(solx_root, "tests", "solidity", "simple", "constants").replace("\\", "/"))
+)
+config.substitutions.append(
     ("%evaluation_order", os.path.join(solx_root, "tests", "solidity", "simple", "evaluation_order").replace("\\", "/"))
 )
 config.substitutions.append(

--- a/solx-mlir/tests/lit/value_transfer.sol
+++ b/solx-mlir/tests/lit/value_transfer.sol
@@ -9,7 +9,20 @@
 // CHECK:   %[[TR:.*]] = sol.address_cast %{{.*}} : !sol.address<payable> to !sol.address
 // CHECK:   sol.transfer %[[TR]], %{{.*}} : !sol.address, ui256
 
+// CHECK: sol.func {{.*}}send_literal{{.*}}-> i1
+// CHECK:   %[[SL:.*]] = sol.constant 1 : ui8
+// CHECK:   %[[SA:.*]] = sol.cast %[[SL]] : ui8 to ui256
+// CHECK:   sol.send %{{.*}}, %[[SA]] : !sol.address, ui256 -> i1
+
+// CHECK: sol.func {{.*}}transfer_literal
+// CHECK:   %[[TL:.*]] = sol.constant 2 : ui8
+// CHECK:   %[[TA:.*]] = sol.cast %[[TL]] : ui8 to ui256
+// CHECK:   sol.transfer %{{.*}}, %[[TA]] : !sol.address, ui256
+
 contract C {
     function pay_send(address payable r, uint256 v) public returns (bool) { return r.send(v); }
     function pay_transfer(address payable r, uint256 v) public { r.transfer(v); }
+
+    function send_literal(address payable r) public returns (bool) { return r.send(1 wei); }
+    function transfer_literal(address payable r) public { r.transfer(2 wei); }
 }

--- a/solx-slang/src/contract/function/expression/assignment.rs
+++ b/solx-slang/src/contract/function/expression/assignment.rs
@@ -60,7 +60,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             _ => self.converted(&right, element_type),
         };
         let (place, r#type) = self.expression_place(&left);
-        let current = place.load(r#type, self);
+        let current = place.load(r#type, self).convert(element_type, self);
         let assigned = match node.operator() {
             AssignmentExpressionOperator::PlusEqual(_) => current.add(rhs, self.checked, self),
             AssignmentExpressionOperator::MinusEqual(_) => {
@@ -81,7 +81,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 unreachable!("`=` is handled above and Solidity has no `>>>`")
             }
         };
-        place.store(assigned, self);
+        place.assign(assigned, r#type, self);
         Some(assigned)
     }
 }

--- a/solx-slang/src/contract/function/expression/call/mod.rs
+++ b/solx-slang/src/contract/function/expression/call/mod.rs
@@ -648,10 +648,12 @@ impl Call {
                 Some(hash(data, scope))
             }
             BuiltIn::Ecrecover => {
-                let values = scope.positional_arguments(arguments);
-                Some(Value::ecrecover(
-                    values[0], values[1], values[2], values[3], scope,
-                ))
+                let word = MlirType::fixed_bytes(scope.melior, solx_utils::BYTE_LENGTH_FIELD);
+                let hash = scope.converted(&arguments[0], word);
+                let v = scope.expression(&arguments[1]);
+                let r = scope.converted(&arguments[2], word);
+                let s = scope.converted(&arguments[3], word);
+                Some(Value::ecrecover(hash, v, r, s, scope))
             }
             BuiltIn::Addmod => Some(scope.modular(arguments, Value::addmod)),
             BuiltIn::Mulmod => Some(scope.modular(arguments, Value::mulmod)),
@@ -870,14 +872,14 @@ impl Call {
             Some(BuiltIn::AddressSend) => {
                 let address =
                     scope.converted(&access.operand(), MlirType::address(scope.melior, false));
-                let values = scope.positional_arguments(arguments);
-                vec![Value::send(address, values[0], scope)]
+                let amount = scope.converted(&arguments[0], MlirType::field(scope.melior));
+                vec![Value::send(address, amount, scope)]
             }
             Some(BuiltIn::AddressTransfer) => {
                 let address =
                     scope.converted(&access.operand(), MlirType::address(scope.melior, false));
-                let values = scope.positional_arguments(arguments);
-                Value::transfer(address, values[0], scope);
+                let amount = scope.converted(&arguments[0], MlirType::field(scope.melior));
+                Value::transfer(address, amount, scope);
                 Vec::new()
             }
             Some(BuiltIn::AbiEncode) => {

--- a/solx-slang/src/contract/function/expression/identifier.rs
+++ b/solx-slang/src/contract/function/expression/identifier.rs
@@ -18,23 +18,43 @@ use crate::scope::function::FunctionScope;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// A constant folds to its initializer; an immutable outside the constructor loads its linked
-    /// value (`sol.load_immutable`); a bare function name materialises its internal pointer
+    /// A constant folds to its initializer converted to the declared type, since the initializer
+    /// alone may carry another (a string literal initializing a `bytesN`); an immutable outside
+    /// the constructor loads its linked value (`sol.load_immutable`); a bare function name
+    /// materialises its internal pointer
     /// (`sol.func_constant`), defining the function in this module if absent; a library name is its
     /// linked address (`sol.lib_addr`); every other identifier loads from its place.
     pub fn identifier(&mut self, node: &Identifier) -> Value<'context> {
         match node.resolve_to_definition() {
             Some(Definition::Constant(constant)) => {
-                self.expression(&constant.value().expect("constant has an initializer"))
+                let declared_type = self
+                    .resolve_type(
+                        &constant.get_type().expect("binder types every constant"),
+                        None,
+                    )
+                    .folded_constant();
+                self.converted(
+                    &constant.value().expect("constant has an initializer"),
+                    declared_type,
+                )
             }
             Some(Definition::StateVariable(state_variable))
                 if let StateVariableMutability::Constant =
                     state_variable.attributes().mutability() =>
             {
-                self.expression(
+                let declared_type = self
+                    .resolve_type(
+                        &state_variable
+                            .get_type()
+                            .expect("binder types every state variable"),
+                        None,
+                    )
+                    .folded_constant();
+                self.converted(
                     &state_variable
                         .value()
                         .expect("a constant state variable is initialized"),
+                    declared_type,
                 )
             }
             Some(Definition::StateVariable(state_variable))

--- a/tests/solidity/simple/constants/constant_fold_declared_type.sol
+++ b/tests/solidity/simple/constants/constant_fold_declared_type.sol
@@ -1,0 +1,101 @@
+//! {
+//!     "cases": [
+//!         {
+//!             "name": "default",
+//!             "inputs": [
+//!                 {
+//!                     "method": "digits",
+//!                     "calldata": [],
+//!                     "expected": [
+//!                         "0x3031323334353637383961626364656600000000000000000000000000000000"
+//!                     ]
+//!                 },
+//!                 {
+//!                     "method": "hexDigit",
+//!                     "calldata": [
+//!                         "0"
+//!                     ],
+//!                     "expected": [
+//!                         "0x3000000000000000000000000000000000000000000000000000000000000000"
+//!                     ]
+//!                 },
+//!                 {
+//!                     "method": "hexDigit",
+//!                     "calldata": [
+//!                         "15"
+//!                     ],
+//!                     "expected": [
+//!                         "0x6600000000000000000000000000000000000000000000000000000000000000"
+//!                     ]
+//!                 },
+//!                 {
+//!                     "method": "pubDigit",
+//!                     "calldata": [
+//!                         "10"
+//!                     ],
+//!                     "expected": [
+//!                         "0x4100000000000000000000000000000000000000000000000000000000000000"
+//!                     ]
+//!                 },
+//!                 {
+//!                     "method": "fileDigit",
+//!                     "calldata": [
+//!                         "0"
+//!                     ],
+//!                     "expected": [
+//!                         "0x4500000000000000000000000000000000000000000000000000000000000000"
+//!                     ]
+//!                 },
+//!                 {
+//!                     "method": "text",
+//!                     "calldata": [],
+//!                     "expected": [
+//!                         "0x0000000000000000000000000000000000000000000000000000000000000020",
+//!                         "0x0000000000000000000000000000000000000000000000000000000000000004",
+//!                         "0x736f6c7800000000000000000000000000000000000000000000000000000000"
+//!                     ]
+//!                 },
+//!                 {
+//!                     "method": "TEXT",
+//!                     "calldata": [],
+//!                     "expected": [
+//!                         "0x0000000000000000000000000000000000000000000000000000000000000020",
+//!                         "0x0000000000000000000000000000000000000000000000000000000000000004",
+//!                         "0x736f6c7800000000000000000000000000000000000000000000000000000000"
+//!                     ]
+//!                 }
+//!             ]
+//!         }
+//!     ]
+//! }
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+bytes16 constant FILE_DIGITS = "EDCBA98765432100";
+
+contract Test {
+    bytes16 private constant HEX_DIGITS = "0123456789abcdef";
+    bytes16 public constant PUB_DIGITS = "0123456789ABCDEF";
+    string public constant TEXT = "solx";
+
+    function digits() external pure returns (bytes16) {
+        return HEX_DIGITS;
+    }
+
+    function hexDigit(uint256 value) external pure returns (bytes1) {
+        return HEX_DIGITS[value & 0xf];
+    }
+
+    function pubDigit(uint256 value) external pure returns (bytes1) {
+        return PUB_DIGITS[value & 0xf];
+    }
+
+    function fileDigit(uint256 value) external pure returns (bytes1) {
+        return FILE_DIGITS[value & 0xf];
+    }
+
+    function text() external pure returns (string memory) {
+        return TEXT;
+    }
+}


### PR DESCRIPTION
This includes:
 - aligning 'sol.byte' with 'bytes1' at conversion boundaries
 - converting arguments for 'sol.ecrecover', 'sol.send', and 'sol.transfer'
 - folding constant identifiers at their declared type
 
Fixed semantic tests:
```
array/indexAccess/bytes_index_access.sol
functionCall/send_zero_ether.sol
isoltestTesting/balance_other_contract.sol
revertStrings/transfer.sol
```