### PR TITLE
ci: port main's CI and dependency changes onto main-slang

### DIFF
--- a/.github/actions/code-changes/action.yml
+++ b/.github/actions/code-changes/action.yml
@@ -17,7 +17,7 @@ runs:
     # 'every': a file counts as code only if no negation pattern excludes it.
     # Not every .md is documentation — solx-benchmark-converter compiles
     # templates/summary.md into the binary and asserts golden .md fixtures.
-    - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+    - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
       id: filter
       with:
         token: ''

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -15,7 +15,7 @@
 #          regression tests, cargo coverage/report tools). Must stay the final
 #          stage: docker-ci-image.yaml publishes the default target.
 
-FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS base
+FROM ubuntu:26.04@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03 AS base
 
 LABEL org.opencontainers.image.source="https://github.com/NomicFoundation/solx"
 LABEL org.opencontainers.image.description="CI runner image for solx"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -79,7 +79,7 @@ jobs:
           optional: 'true'
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: coverage-v1
           cache-on-failure: true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -232,6 +232,10 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        with:
+          # Pinning the action digest alone still floats the frontend: this input defaults to `stable`.
+          # renovate: datasource=github-releases depName=foundry-rs/foundry
+          version: v1.7.1
 
       # Some projects might use hardcoded ssh URLs: force git to use https instead.
       - name: Git https settings

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -595,7 +595,7 @@ jobs:
             }
 
       - name: Binaries attestation
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         if: github.ref_type == 'tag'
         with:
           subject-path: 'releases/**/**'

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -131,7 +131,7 @@ jobs:
       - sanitizer
     steps:
       - name: Decide on PR checks
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
       # rust-toolchain.toml because the container resolves it lazily on first
       # use; this workflow itself so edits to the validation harness (the
       # validate-devcontainer job, the devcontainers/ci pin) are validated too.
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter-devcontainer
         with:
           token: ''
@@ -55,7 +55,7 @@ jobs:
       # docs_examples CLI test), but they live under docs/ which the code
       # filter excludes — without this, a docs-only PR would skip the very
       # test that guards it.
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter-docs-examples
         with:
           filters: |
@@ -127,7 +127,7 @@ jobs:
           solc: 'false'
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: cargo-checks-v1
           cache-on-failure: true
@@ -263,7 +263,7 @@ jobs:
           echo "After cleanup:" && df -h .
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: slang-tests-v2
           cache-on-failure: true
@@ -320,7 +320,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+      - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: zizmor@1.26.1
       # GH_TOKEN enables the online audits (known-vulnerabilities, tag->SHA resolution).

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -343,7 +343,7 @@ jobs:
       - zizmor
     steps:
       - name: Decide on PR checks
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: >-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1723,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3035,7 +3035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3982,9 +3982,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust_xlsxwriter"
-version = "0.96.0"
+version = "0.97.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1746025420e17b5d62528b930e550e016e857038794d74e169018126ef3d14"
+checksum = "210c9bee5c2d1df2c3a4fa1fccf3647a37bea205a35d5775491731b271bff19b"
 dependencies = [
  "zip",
 ]
@@ -4029,7 +4029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4086,7 +4086,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5000,7 +5000,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5135,7 +5134,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5144,7 +5143,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5775,7 +5774,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6160,9 +6159,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1159,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "finl_unicode"
@@ -5131,7 +5131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5187,18 +5187,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "flate2",
  "memchr",
@@ -4115,9 +4115,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]
@@ -4710,7 +4710,7 @@ dependencies = [
  "hex",
  "inkwell",
  "libc",
- "object 0.39.1",
+ "object 0.40.0",
  "predicates",
  "semver 1.0.28",
  "serde",
@@ -4914,7 +4914,7 @@ dependencies = [
  "hex",
  "itertools 0.15.0",
  "md5",
- "object 0.39.1",
+ "object 0.40.0",
  "once_cell",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ semver = { version = "1.0", features = ["serde"] }
 gimli = "0.34"
 hex = "0.4"
 num = "0.4"
-object = "0.39"
+object = "0.40"
 regex = "1.12"
 glob = "0.3"
 itertools = "0.15"

--- a/deny.toml
+++ b/deny.toml
@@ -1,18 +1,25 @@
 [advisories]
 yanked = "deny"
 
-# arrayref 0.3.5-0.3.9 -- every version satisfying our dependents' ^0.3.5
-# (blake2b_simd/blake2s_simd) and ^0.3.6 (revm-precompile) -- were yanked on
-# 2026-08-20, leaving 0.3.10 as the only resolvable version. 0.3.10 adds a
-# dependency on `proc-macro1`, a typosquat of proc-macro2 pulling in ureq and
-# rustls, which crates.io has since deleted outright rather than yanked. Its
-# src/lib.rs is byte-identical to 0.3.9's and it has no corresponding upstream
-# commit or tag, so the release carries no fix -- only the new dependency.
-# Hold at 0.3.9 and do NOT run `cargo update -p arrayref`, which cargo-deny's
-# own error message suggests. Drop this entry once a clean version ships or the
-# yanks are reverted.
+# chacha20 0.10.0 and 0.10.1 were yanked on 2026-08-27: the SSE2 backend wrote
+# the counter back with `_mm_extract_epi32`, an SSE4.1 intrinsic, on a path
+# guarded only by `target_feature(enable = "sse2")`. That emits PEXTRD where
+# only SSE2 is guaranteed, so it traps on x86_64 CPUs without SSE4.1 -- and the
+# SSE2 backend is precisely the fallback those CPUs take. 0.10.2 replaces both
+# writebacks with a single `_mm_storeu_si128`; the extra lanes it stores are the
+# nonce, which the counter add never touches, so the fix is equivalent.
+#
+# solx never runs that code. chacha20 arrives with only the `rng` feature via
+# solx-evm-assembly -> twox-hash -> rand, and twox-hash calls `rand::random()`
+# from exactly two places, `xxhash32::RandomState::new` and its xxhash64 twin.
+# solx uses `XxHash3_64::default()` and `XxHash3_64::oneshot()`, both
+# deterministic, so the ChaCha RNG is compiled in and never entered.
+#
+# 0.10.2 lands inside our 7-day cooldown until 2026-09-03 17:51 UTC. Holding an
+# unreachable yanked version for that window beats allowlisting a fresh crate
+# past the gate. Drop this entry and take 0.10.2 once the cooldown expires.
 ignore = [
-    { crate = "arrayref@0.3.9", reason = "yanked to force resolution onto the compromised 0.3.10; see comment above" },
+    { crate = "chacha20@0.10.1", reason = "SSE4.1 intrinsic on the SSE2 path; unreachable from solx, and 0.10.2 is held until its cooldown expires 2026-09-03" },
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,20 @@
 [advisories]
 yanked = "deny"
 
+# arrayref 0.3.5-0.3.9 -- every version satisfying our dependents' ^0.3.5
+# (blake2b_simd/blake2s_simd) and ^0.3.6 (revm-precompile) -- were yanked on
+# 2026-08-20, leaving 0.3.10 as the only resolvable version. 0.3.10 adds a
+# dependency on `proc-macro1`, a typosquat of proc-macro2 pulling in ureq and
+# rustls, which crates.io has since deleted outright rather than yanked. Its
+# src/lib.rs is byte-identical to 0.3.9's and it has no corresponding upstream
+# commit or tag, so the release carries no fix -- only the new dependency.
+# Hold at 0.3.9 and do NOT run `cargo update -p arrayref`, which cargo-deny's
+# own error message suggests. Drop this entry once a clean version ships or the
+# yanks are reverted.
+ignore = [
+    { crate = "arrayref@0.3.9", reason = "yanked to force resolution onto the compromised 0.3.10; see comment above" },
+]
+
 [licenses]
 allow = [
     "GPL-3.0-only",

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,16 @@
       ],
       "depNameTemplate": "rust",
       "datasourceTemplate": "rust-version"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the Foundry release the integration workflow installs. Pinning the foundry-toolchain action digest is not enough: its `version` input defaults to `stable`, so the compiler frontend floated free of any pin. forge 1.8.1 shipped a lint-on-build ICE (foundry-rs/foundry#16473) that turned the foundry leg red on an unrelated PR, with no version bump anywhere for Renovate to see. Unlike the managers above this one reads datasource/depName from the `# renovate:` marker comment, so the regex anchors to the pinned value rather than to the step's YAML shape.",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/integration-tests\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+version: (?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ]
     }
   ],
   "packageRules": [
@@ -103,6 +113,12 @@
       "matchManagers": ["custom.regex"],
       "matchDepNames": ["hardhat"],
       "allowedVersions": "<3"
+    },
+    {
+      "description": "Hold Foundry on 1.7.x until the harness is ported to 1.8. Two 1.8.x changes break solx-dev/src/test/foundry: `forge build` runs the linter unless `--no-lint` is passed, and 1.8.1's linter ICEs on aave-v3 (foundry-rs/foundry#16473, fixed after the 1.8.1 cut); and `--fuzz-runs 0` is rejected outright, while the harness relies on 0 to leave fuzz tests unexecuted and contributing zero gas — raising it to 1 executes them across every project, shifting both the pass/fail surface and the benchmark baselines. v1.7.1 is the toolchain the suite was green on until 2026-08-27. Drop this rule once that port lands.",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["foundry-rs/foundry"],
+      "allowedVersions": "<1.8"
     },
     {
       "description": "custom.regex deps only feed the integration harness; label so the gated suite runs.",

--- a/solx-benchmark-converter/Cargo.toml
+++ b/solx-benchmark-converter/Cargo.toml
@@ -21,7 +21,7 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 glob.workspace = true
-rust_xlsxwriter = "0.96"
+rust_xlsxwriter = "0.97"
 askama = "0.16"
 
 [dev-dependencies]

--- a/solx-dev/hardhat-tests.toml
+++ b/solx-dev/hardhat-tests.toml
@@ -39,7 +39,7 @@
 
 [build_systems]
 yarn = "1.22.22"
-pnpm = "11.21.0"
+pnpm = "11.22.0"
 bun = "1.3.14"
 
 [compilers.solc]

--- a/solx-dev/hardhat-tests.toml
+++ b/solx-dev/hardhat-tests.toml
@@ -39,7 +39,7 @@
 
 [build_systems]
 yarn = "1.22.22"
-pnpm = "11.19.0"
+pnpm = "11.21.0"
 bun = "1.3.14"
 
 [compilers.solc]


### PR DESCRIPTION
Ports main's CI and dependency changes onto `main-slang`, which has been diverging since `a85ef238` (2026-08-08). Two of them fix CI that is currently red on **every** PR in the main-slang stack.

Cherry-picks only, `-x` so each commit records the main SHA it came from. No feature work, no submodule change.

## Why now

`main-slang` is failing two gates on every PR, neither caused by anything in this repo:

- **zizmor** — `re-actors/alls-green` moved its rolling `release/v1` branch onto v1.3.0 on 2026-08-21, so our SHA pin's `# release/v1` comment stopped resolving to the pinned commit and `ref-version-mismatch` began failing. The SHA never moved and is what actually runs; only the comment went stale. Fixed by naming the immutable tag (`# v1.2.2`) instead of a branch that keeps moving.
- **cargo-deny** — `chacha20` 0.10.0/0.10.1 were yanked on 2026-08-27 (SSE4.1 intrinsic on an SSE2-guarded path). 0.10.2 fixes it but was inside our 7-day cooldown, so this holds the yanked version with a documented, time-boxed ignore rather than allowlisting a three-day-old crate past the gate. The defect is unreachable from solx — see the `deny.toml` comment.

Also picks up the Foundry pin from #673. That one matters here: the digest-pinned `foundry-toolchain` action still defaults its `version:` input to `stable`, so without it the foundry leg floats onto 1.8.x and hits the lint-on-build ICE.

## Included

| commit | from |
|---|---|
| ubuntu:26.04 digest | #655 |
| pnpm 11.21.0 | #658 |
| github-actions SHA bumps | #657 |
| rust_xlsxwriter 0.97 | #660 |
| object 0.40 | #659 |
| cargo minor/patch | #656 |
| arrayref 0.3.9 hold | #669 |
| cc 1.4.4 + the two CI fixes above | #672 |
| pnpm 11.22.0 + Foundry v1.7.1 pin | #673 |

#669 and #672 both land even though the second removes the first's arrayref block: crates.io reverted those yanks and deleted the compromised 0.3.10 outright, so the hold is dead config. Taking only #672 would conflict against a block that never existed here, and this keeps the history honest.

## Deliberately not included

`#662` (touches the `solx-solidity` submodule), `#664`/`#665` (BLOBHASH, SELFDESTRUCT), `#663`/`#666` (source behaviour), `#668` (0.1.8 version bump — a release chore).

A real `main` → `main-slang` merge is still blocked on the submodule: the `solx-solidity` pointers genuinely diverge, with main-slang's commit 1014 ahead of main's and main's 6 ahead of main-slang's. That needs its own merge in the fork before the feature commits can follow.

## Two conflicts worth reviewing

**`test.yaml` on #657.** main-slang inserts a MinGW bindgen step where main has its `rust-cache` step, so git offered main's version of that step wholesale — including `prefix-key: build-and-test-v2` and `save-if: refs/heads/main`. Accepting that would have silently repointed main-slang's cache keys and stopped it saving on its own branch. Resolved by keeping main-slang's step and bumping the SHA in place on both of its cache steps, preserving `cargo-checks-v1` / `slang-tests-v2` and `refs/heads/main-slang`. Verified no stale #657 SHAs remain anywhere under `.github`.

**`Cargo.lock` on #660.** Not hand-merged. Took main-slang's lock and ran `cargo update -p rust_xlsxwriter --precise 0.97.1`, which pulled `zip 7.2.0 → 8.6.0` exactly as main resolved it. Both are months outside the cooldown window.

## Verification

Run locally against this branch, using CI's exact invocations:

| check | result |
|---|---|
| `cargo deny --all-features check --allow unmaintained --hide-inclusion-graph` | `advisories ok, bans ok, licenses ok, sources ok`, exit 0 |
| `zizmor` 1.26.1, online, whole `.github` | no findings, exit 0 |
| `actionlint` with `SHELLCHECK_OPTS=--severity=warning` | exit 0 |
| `cargo metadata --locked` | resolves |

`renovate.json` and `solx-dev/hardhat-tests.toml` came out byte-identical to main. The Foundry pin was confirmed to land on the repo's only `foundry-toolchain` step, not merely to apply cleanly.

## Follow-up

Drop the `chacha20@0.10.1` entry and take 0.10.2 once its cooldown expires on **2026-09-03 17:51 UTC**. The `deny.toml` comment states that condition inline.
