### PR TITLE
fix(slang): constants at their declared type, compound assignment on bytes elements

### DIFF
--- a/solx-mlir/tests/lit/compound_assignment.sol
+++ b/solx-mlir/tests/lit/compound_assignment.sol
@@ -101,6 +101,18 @@
 // CHECK-SOLC:   sol.shr %[[OLD]], %[[SHR_AMOUNT]] : ui256, ui256
 // CHECK:   sol.store %{{.*}}, %[[XPTR]]
 
+// CHECK: sol.func @{{.*xor_assign_byte.*}}
+// CHECK-SOLX:   %[[RHS:.*]] = sol.bytes_cast %{{.*}} : ui8 to !sol.fixedbytes<1>
+// CHECK-SOLX:   %[[OLD:.*]] = sol.load %[[BPTR:.*]] : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK-SOLX:   %[[OLD_BYTES:.*]] = sol.bytes_cast %[[OLD]] : !sol.byte to !sol.fixedbytes<1>
+// CHECK-SOLX:   %[[NEW:.*]] = sol.xor %[[OLD_BYTES]], %[[RHS]] : !sol.fixedbytes<1>
+// CHECK-SOLX:   %[[NEW_BYTE:.*]] = sol.bytes_cast %[[NEW]] : !sol.fixedbytes<1> to !sol.byte
+// CHECK-SOLX:   sol.store %[[NEW_BYTE]], %[[BPTR]] : !sol.byte, !sol.ptr<!sol.byte, Memory>
+// CHECK-SOLC:   %[[OLD:.*]] = sol.load %[[BPTR:.*]] : !sol.ptr<!sol.byte, Memory>, !sol.byte
+// CHECK-SOLC:   %[[RHS:.*]] = sol.bytes_cast %{{.*}} : ui8 to !sol.byte
+// CHECK-SOLC:   %[[NEW:.*]] = sol.xor %[[OLD]], %[[RHS]] : !sol.byte
+// CHECK-SOLC:   sol.store %[[NEW]], %[[BPTR]] : !sol.byte, !sol.ptr<!sol.byte, Memory>
+
 contract C {
     function add_assign(uint256 x, uint256 y) public pure returns (uint256) {
         x += y;
@@ -160,5 +172,10 @@ contract C {
     function shr_assign_mixed(uint256 x, uint8 y) public pure returns (uint256) {
         x >>= y;
         return x;
+    }
+
+    function xor_assign_byte(bytes memory b, uint256 i) public pure returns (bytes memory) {
+        b[i] ^= 0x20;
+        return b;
     }
 }

--- a/solx-mlir/tests/lit/index_access.sol
+++ b/solx-mlir/tests/lit/index_access.sol
@@ -13,6 +13,11 @@
 // CHECK: sol.func {{.*}}readFixedBytes{{.*}}-> !sol.fixedbytes<1>
 // CHECK:   sol.fixed_bytes_index %{{.*}}[%{{.*}}] : !sol.fixedbytes<32>, ui256 -> !sol.fixedbytes<1>
 
+// CHECK: sol.func {{.*}}readConstantBytes{{.*}}-> !sol.fixedbytes<1>
+// CHECK:   sol.constant 64058384521018188869745042196707698022 : ui128
+// CHECK:   sol.bytes_cast %{{.*}} : ui128 to !sol.fixedbytes<16>
+// CHECK:   sol.fixed_bytes_index %{{.*}}[%{{.*}}] : !sol.fixedbytes<16>, ui256 -> !sol.fixedbytes<1>
+
 // CHECK: sol.func {{.*}}readMapping{{.*}}-> ui256
 // CHECK:   sol.map %{{.*}}, %{{.*}} : !sol.mapping<ui256, ui256>, ui256, !sol.ptr<ui256, Storage>
 // CHECK:   sol.load %{{.*}} : !sol.ptr<ui256, Storage>, ui256
@@ -38,6 +43,7 @@ contract C {
     mapping(uint256 => uint256) map;
     mapping(bytes32 => uint256) wordMap;
     mapping(int256 => uint256) signedMap;
+    bytes16 private constant HEX_DIGITS = "0123456789abcdef";
 
     function readArray(uint256[] memory array, uint256 index) public pure returns (uint256) {
         return array[index];
@@ -49,6 +55,10 @@ contract C {
 
     function readFixedBytes(bytes32 word, uint256 index) public pure returns (bytes1) {
         return word[index];
+    }
+
+    function readConstantBytes(uint256 value) public pure returns (bytes1) {
+        return HEX_DIGITS[value & 0xf];
     }
 
     function readMapping(uint256 key) public view returns (uint256) {

--- a/solx-slang/src/contract/function/expression/assignment.rs
+++ b/solx-slang/src/contract/function/expression/assignment.rs
@@ -60,7 +60,9 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
             _ => self.converted(&right, element_type),
         };
         let (place, r#type) = self.expression_place(&left);
-        let current = place.load(r#type, self);
+        // A `bytes` element loads as `!sol.byte` while the binder types it `bytes1`: operate at the
+        // binder's type and store back through the place's.
+        let current = place.load(r#type, self).bytes_cast(element_type, self);
         let assigned = match node.operator() {
             AssignmentExpressionOperator::PlusEqual(_) => current.add(rhs, self.checked, self),
             AssignmentExpressionOperator::MinusEqual(_) => {
@@ -81,7 +83,7 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 unreachable!("`=` is handled above and Solidity has no `>>>`")
             }
         };
-        place.store(assigned, self);
+        place.store(assigned.bytes_cast(r#type, self), self);
         Some(assigned)
     }
 }

--- a/solx-slang/src/contract/function/expression/identifier.rs
+++ b/solx-slang/src/contract/function/expression/identifier.rs
@@ -4,8 +4,10 @@
 //!
 
 use slang_solidity_v2::ast::Definition;
+use slang_solidity_v2::ast::Expression;
 use slang_solidity_v2::ast::Identifier;
 use slang_solidity_v2::ast::StateVariableMutability;
+use slang_solidity_v2::ast::Type;
 
 use solx_mlir::FunctionDispatch;
 use solx_mlir::FunctionKind;
@@ -18,23 +20,26 @@ use crate::scope::function::FunctionScope;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, 'context> {
-    /// A constant folds to its initializer; an immutable outside the constructor loads its linked
-    /// value (`sol.load_immutable`); a bare function name materialises its internal pointer
-    /// (`sol.func_constant`), defining the function in this module if absent; a library name is its
-    /// linked address (`sol.lib_addr`); every other identifier loads from its place.
+    /// A constant folds to its initializer at its declared type; an immutable outside the
+    /// constructor loads its linked value (`sol.load_immutable`); a bare function name materialises
+    /// its internal pointer (`sol.func_constant`), defining the function in this module if absent;
+    /// a library name is its linked address (`sol.lib_addr`); every other identifier loads from
+    /// its place.
     pub fn identifier(&mut self, node: &Identifier) -> Value<'context> {
         match node.resolve_to_definition() {
-            Some(Definition::Constant(constant)) => {
-                self.expression(&constant.value().expect("constant has an initializer"))
-            }
+            Some(Definition::Constant(constant)) => self.constant_value(
+                &constant.value().expect("constant has an initializer"),
+                constant.get_type(),
+            ),
             Some(Definition::StateVariable(state_variable))
                 if let StateVariableMutability::Constant =
                     state_variable.attributes().mutability() =>
             {
-                self.expression(
+                self.constant_value(
                     &state_variable
                         .value()
                         .expect("a constant state variable is initialized"),
+                    state_variable.get_type(),
                 )
             }
             Some(Definition::StateVariable(state_variable))
@@ -69,6 +74,18 @@ impl<'contract, 'source_unit, 'context> FunctionScope<'contract, 'source_unit, '
                 place.load(element_type, self)
             }
         }
+    }
+
+    /// A constant's initializer converted to the constant's declared type: the binder types the
+    /// initializer on its own (`bytes16 constant X = "0123456789abcdef"` is a `string` literal),
+    /// and uses such as `X[i]` need the declared `!sol.fixedbytes<16>`.
+    fn constant_value(
+        &mut self,
+        initializer: &Expression,
+        declared_type: Option<Type>,
+    ) -> Value<'context> {
+        let declared_type = self.typing(declared_type);
+        self.converted(initializer, declared_type)
     }
 
     /// A state variable resolves to its storage slot, a local variable or parameter to its stack


### PR DESCRIPTION

Fixes bucket 2 of the Sourcify sweep (#685, run 1): 10,457 contracts failing with

```
error: 'sol.fixed_bytes_index' op operand #0 must be <fixed bytes>, but got '!sol.string<Memory>'
```

The sweep row called this `bytes memory` indexing; it is not. `bytes memory` indexing already works (`readBytes` in `index_access.sol`). The trigger is the OpenZeppelin `Strings` idiom:

```solidity
bytes16 private constant HEX_DIGITS = "0123456789abcdef";
buffer[i] = HEX_DIGITS[value & 0xf];
```

A constant folded to its initializer at the initializer's own type, so the string literal became a `!sol.string<Memory>` and `HEX_DIGITS[i]` reached `sol.fixed_bytes_index` with the wrong operand. The constant getter and the inline-assembly reference already fold through `converted` to the declared type; the identifier path now does the same (first commit).

9,907 of those contracts also reported

```
error: 'sol.xor' op requires the same type for all operands and results
```

from OpenZeppelin 5.1's `toChecksumHexString`, `buffer[i] ^= 0x20`. Compound assignment loaded the element as `!sol.byte` but converted the right-hand side to the binder's `bytes1`. It now operates at the binder's type and casts back for the store, as value-position indexing already does after its load (second commit). No record in the sweep had the xor error alone, so both fixes are needed to clear the bucket.

Two lit cases, one per bug, in `index_access.sol` and `compound_assignment.sol`. Both fail on the pre-fix build with exactly the two errors above and pass on this branch. The solc fork lowers `b[i] ^= 0x20` at `!sol.byte` where Slang uses `!sol.fixedbytes<1>` with casts around the operator; the file's existing `CHECK-SOLX`/`CHECK-SOLC` split records both.

Verified locally with an MLIR-enabled toolchain: `llvm-lit solx-mlir/tests/lit/` 134/134 on both frontends, `cargo test-slang` 201 passed. Corpus-level confirmation waits for sweep run 3 on the sweep branch: the OZ 5.x bundles also need inline assembly (#671) and the klaytn bundles remappings (#684), so they cannot compile on `main` alone.
