### PR TITLE
feat: bump slang_solidity_v2 and update API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1723,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3035,7 +3035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4029,7 +4029,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4086,7 +4086,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4567,8 +4567,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slang_solidity_v2"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 dependencies = [
+ "rayon",
  "slang_solidity_v2_ast",
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
@@ -4580,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_ast"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 dependencies = [
  "itertools 0.15.0",
  "num-bigint",
@@ -4597,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_common"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 dependencies = [
  "fxhash",
  "indexmap 2.14.0",
@@ -4611,13 +4612,14 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_cst"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 
 [[package]]
 name = "slang_solidity_v2_ir"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 dependencies = [
+ "semver 1.0.28",
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
 ]
@@ -4625,12 +4627,11 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_parser"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
  "logos",
- "regex",
  "slang_solidity_v2_common",
  "slang_solidity_v2_cst",
  "strum",
@@ -4639,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "slang_solidity_v2_semantic"
 version = "1.3.8"
-source = "git+https://github.com/NomicFoundation/slang.git?rev=8948967bda8badbc225339b4b97764d13688f2c6#8948967bda8badbc225339b4b97764d13688f2c6"
+source = "git+https://github.com/NomicFoundation/slang.git?rev=b34370a00d5ff963f93af6b142ea77436b1760bb#b34370a00d5ff963f93af6b142ea77436b1760bb"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -5131,10 +5132,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5143,7 +5144,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5774,7 +5775,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,4 @@ features = [
 [workspace.dependencies.slang_solidity_v2]
 git = "https://github.com/NomicFoundation/slang.git"
 # TODO: pin to a release tag instead of a revision.
-rev = "8948967bda8badbc225339b4b97764d13688f2c6"
+rev = "b34370a00d5ff963f93af6b142ea77436b1760bb"

--- a/solx-slang/src/slang/import_resolver.rs
+++ b/solx-slang/src/slang/import_resolver.rs
@@ -1,39 +1,22 @@
 //!
-//! Compilation builder configuration for the Slang frontend.
+//! Import resolution for the Slang frontend.
 //!
 
 use std::collections::BTreeMap;
 use std::path::Component;
 use std::path::Path;
 
-use slang_solidity_v2::compilation::CompilationBuilderConfig;
 use slang_solidity_v2::compilation::FileId;
-use slang_solidity_v2::diagnostics::kinds::compilation::MissingFile;
+use slang_solidity_v2::compilation::ImportResolver;
 use slang_solidity_v2::diagnostics::kinds::compilation::UnresolvedImport;
 
-/// Provides file reading and import resolution for the Slang compilation builder.
-pub struct CompilationConfig {
-    /// The file contents keyed by identifier, for reading and import resolution.
-    pub sources: BTreeMap<FileId, String>,
+/// Resolves import paths to the source files provided to the compilation.
+pub struct SourceImportResolver<'a> {
+    /// The source files keyed by identifier; an import resolves only to one of them.
+    pub sources: &'a BTreeMap<FileId, &'a str>,
 }
 
-impl CompilationConfig {
-    /// Creates a new configuration from a map of file identifiers to source contents.
-    pub fn new(sources: BTreeMap<FileId, String>) -> Self {
-        Self { sources }
-    }
-}
-
-impl CompilationBuilderConfig for CompilationConfig {
-    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
-        self.sources
-            .get(file_id)
-            .cloned()
-            .ok_or_else(|| MissingFile {
-                reason: format!("file not found {file_id}"),
-            })
-    }
-
+impl ImportResolver for SourceImportResolver<'_> {
     fn resolve_import(
         &mut self,
         source_file_id: &FileId,

--- a/solx-slang/src/slang/mod.rs
+++ b/solx-slang/src/slang/mod.rs
@@ -2,13 +2,13 @@
 //! Slang Solidity frontend implementation.
 //!
 
-mod compilation_config;
+mod import_resolver;
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use slang_solidity_v2::compilation::CompilationBuilder;
 use slang_solidity_v2::compilation::CompilationUnit;
+use slang_solidity_v2::compilation::Configuration;
 use slang_solidity_v2::compilation::FileId;
 use slang_solidity_v2::diagnostics::DiagnosticExtensions;
 use slang_solidity_v2::utils::EvmTarget;
@@ -20,7 +20,7 @@ use solx_standard_json::output::error::source_location::SourceLocation;
 
 use crate::scope::source_unit::SourceUnitScope;
 
-use self::compilation_config::CompilationConfig;
+use self::import_resolver::SourceImportResolver;
 
 /// The Slang frontend implementation.
 #[derive(Debug)]
@@ -51,25 +51,24 @@ impl Slang {
     ///
     /// # Errors
     ///
-    /// Returns an error if the compilation builder fails to initialize or if import resolution
-    /// fails.
-    fn compile(&self, sources: BTreeMap<FileId, String>) -> anyhow::Result<CompilationUnit> {
-        let file_ids: Vec<FileId> = sources.keys().cloned().collect();
-        let configuration = CompilationConfig::new(sources);
-        let version: LanguageVersion =
+    /// Returns an error if Slang does not support the Solidity version.
+    fn compile(&self, sources: &BTreeMap<FileId, &str>) -> anyhow::Result<CompilationUnit> {
+        let language_version: LanguageVersion =
             self.version.default.clone().try_into().map_err(|error| {
                 anyhow::anyhow!(
                     "failed to convert Solidity version '{}' to a Slang language version: {error}",
                     self.version.default
                 )
             })?;
-        let mut builder = CompilationBuilder::create(version, EvmTarget::LATEST, configuration);
 
-        for file_id in file_ids {
-            builder.add_file(file_id);
-        }
-
-        Ok(builder.build())
+        Ok(CompilationUnit::create(Configuration {
+            language_version,
+            evm_target: EvmTarget::LATEST,
+            sources: sources
+                .iter()
+                .map(|(file_id, content)| (file_id.clone(), *content)),
+            resolver: SourceImportResolver { sources },
+        }))
     }
 }
 
@@ -122,10 +121,10 @@ impl Frontend for Slang {
                     ));
                 continue;
             };
-            sources.insert(path.as_str().into(), source_code.to_owned());
+            sources.insert(path.as_str().into(), source_code);
         }
 
-        let unit = self.compile(sources)?;
+        let unit = self.compile(&sources)?;
 
         output
             .errors

--- a/solx-tester/src/compilers/solidity/slang_ast.rs
+++ b/solx-tester/src/compilers/solidity/slang_ast.rs
@@ -7,11 +7,10 @@ use std::collections::BTreeMap;
 use slang_solidity_v2::ast::AbicoderVersion;
 use slang_solidity_v2::ast::Pragma;
 use slang_solidity_v2::ast::SourceUnitMember;
-use slang_solidity_v2::compilation::CompilationBuilder;
-use slang_solidity_v2::compilation::CompilationBuilderConfig;
 use slang_solidity_v2::compilation::CompilationUnit;
+use slang_solidity_v2::compilation::Configuration;
 use slang_solidity_v2::compilation::FileId;
-use slang_solidity_v2::diagnostics::kinds::compilation::MissingFile;
+use slang_solidity_v2::compilation::ImportResolver;
 use slang_solidity_v2::diagnostics::kinds::compilation::UnresolvedImport;
 use slang_solidity_v2::utils::EvmTarget;
 use slang_solidity_v2::utils::LanguageVersion;
@@ -42,23 +41,15 @@ impl SlangAst {
             .iter()
             .map(|(path, _source_code)| FileId::from(path.as_str()))
             .collect();
-        let mut builder = CompilationBuilder::create(
-            LanguageVersion::LATEST,
-            EvmTarget::LATEST,
-            TestSources(
-                sources
-                    .iter()
-                    .map(|(path, source_code)| (FileId::from(path.as_str()), source_code.clone()))
-                    .collect(),
-            ),
-        );
-        for file_id in files.iter() {
-            builder.add_file(file_id.clone());
-        }
-        Self {
-            unit: builder.build(),
-            files,
-        }
+        let unit = CompilationUnit::create(Configuration {
+            language_version: LanguageVersion::LATEST,
+            evm_target: EvmTarget::LATEST,
+            sources: sources
+                .iter()
+                .map(|(path, source_code)| (FileId::from(path.as_str()), source_code.as_str())),
+            resolver: VerbatimImportResolver,
+        });
+        Self { unit, files }
     }
 
     ///
@@ -121,32 +112,19 @@ impl SlangAst {
 }
 
 ///
-/// Serves source contents to the compilation builder.
+/// Resolves an import path to the test file of that exact name.
 ///
-/// Import resolution is an exact lookup among the test's own files: the tester's queries
-/// are syntactic, so an unresolved import costs nothing beyond an unused diagnostic.
+/// Slang reports an import of a file outside the test's own sources; the tester's queries
+/// are syntactic, so it costs nothing beyond an unused diagnostic.
 ///
-struct TestSources(BTreeMap<FileId, String>);
+struct VerbatimImportResolver;
 
-impl CompilationBuilderConfig for TestSources {
-    fn read_file(&mut self, file_id: &FileId) -> Result<String, MissingFile> {
-        self.0.get(file_id).cloned().ok_or_else(|| MissingFile {
-            reason: format!("file not found {file_id}"),
-        })
-    }
-
+impl ImportResolver for VerbatimImportResolver {
     fn resolve_import(
         &mut self,
-        source_file_id: &FileId,
+        _source_file_id: &FileId,
         import_path: &str,
     ) -> Result<FileId, UnresolvedImport> {
-        let candidate = FileId::from(import_path);
-        if self.0.contains_key(&candidate) {
-            Ok(candidate)
-        } else {
-            Err(UnresolvedImport {
-                reason: format!("failed to resolve import {import_path} in {source_file_id}"),
-            })
-        }
+        Ok(import_path.into())
     }
 }


### PR DESCRIPTION
Bumps `slang_solidity_v2` from `8948967` to slang main `b34370a0` and ports the Slang frontend and the tester's `slang-ast` view to the push-based `CompilationUnit::create` API from NomicFoundation/slang#2068, which replaced `CompilationBuilder` and dropped the `MissingFile` diagnostic. Import resolution behaviour is unchanged; the frontend now borrows sources instead of cloning them, and the tester's resolver delegates the file-membership check to slang.