### PR TITLE
feat(slang): emit the JSON ABI and enable `--abi` and `--hashes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4862,6 +4862,7 @@ dependencies = [
  "num-traits",
  "ruint",
  "semver 1.0.28",
+ "serde",
  "serde_json",
  "slang_solidity_v2",
  "solx-core",

--- a/solx-core/src/arguments.rs
+++ b/solx-core/src/arguments.rs
@@ -515,6 +515,12 @@ impl Arguments {
         if self.output_metadata {
             selectors.insert(solx_standard_json::InputSelector::Metadata);
         }
+        if self.output_abi {
+            selectors.insert(solx_standard_json::InputSelector::ABI);
+        }
+        if self.output_hashes {
+            selectors.insert(solx_standard_json::InputSelector::MethodIdentifiers);
+        }
 
         #[cfg(feature = "solc")]
         {
@@ -531,12 +537,6 @@ impl Arguments {
             }
             if self.output_debug_info_runtime {
                 selectors.insert(solx_standard_json::InputSelector::RuntimeBytecodeDebugInfo);
-            }
-            if self.output_abi {
-                selectors.insert(solx_standard_json::InputSelector::ABI);
-            }
-            if self.output_hashes {
-                selectors.insert(solx_standard_json::InputSelector::MethodIdentifiers);
             }
             if self.output_userdoc {
                 selectors.insert(solx_standard_json::InputSelector::UserDocumentation);

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 num.workspace = true
 num-traits = "0.2"
 ruint.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 semver.workspace = true
 

--- a/solx-slang/src/abi.rs
+++ b/solx-slang/src/abi.rs
@@ -1,14 +1,22 @@
 //!
-//! The JSON ABI of a deployable object in solc's spelling. Slang computes every entry, its sort
-//! order and its getter flattening; this module only renders them.
+//! The JSON ABI of a contract, interface or library in solc's spelling. Slang computes every
+//! entry, its order and its getter flattening; this module only renders them.
 //!
+
+use std::collections::BTreeMap;
 
 use serde::Serialize;
 use slang_solidity_v2::abi::AbiEntry;
 use slang_solidity_v2::abi::AbiMutability;
 use slang_solidity_v2::abi::AbiParameter;
 use slang_solidity_v2::abi::AbiType;
-use slang_solidity_v2::abi::ContractAbi;
+use slang_solidity_v2::ast::ContractDefinition;
+use slang_solidity_v2::ast::ContractMember;
+use slang_solidity_v2::ast::FunctionDefinition;
+use slang_solidity_v2::ast::FunctionKind;
+use slang_solidity_v2::ast::InterfaceDefinition;
+use slang_solidity_v2::ast::LibraryDefinition;
+use slang_solidity_v2::ast::StateVariableDefinition;
 
 /// The `abi` field of a standard-JSON contract: the entries in Slang's order, which is solc's.
 ///
@@ -22,17 +30,123 @@ impl Abi {
     pub fn into_value(self) -> serde_json::Value {
         serde_json::to_value(self).expect("the ABI only holds strings, booleans and lists")
     }
-}
 
-impl From<&[AbiEntry]> for Abi {
-    fn from(entries: &[AbiEntry]) -> Self {
+    /// Composes the ABI of a definition Slang has no whole ABI for from the entries it computes
+    /// per member, in Slang's order.
+    fn from_members(members: impl Iterator<Item = ContractMember>) -> Self {
+        let mut entries = members
+            .filter_map(|member| match member {
+                ContractMember::FunctionDefinition(function) => function.compute_abi_entry(),
+                ContractMember::ErrorDefinition(error) => error.compute_abi_entry(),
+                ContractMember::EventDefinition(event) => event.compute_abi_entry(),
+                _ => None,
+            })
+            .collect::<Vec<AbiEntry>>();
+        entries.sort();
         Self(entries.iter().map(Entry::from).collect())
     }
 }
 
-impl From<&ContractAbi> for Abi {
-    fn from(abi: &ContractAbi) -> Self {
-        Self::from(abi.entries())
+impl From<&ContractDefinition> for Abi {
+    fn from(contract: &ContractDefinition) -> Self {
+        let abi = contract
+            .compute_abi()
+            .expect("slang admits a contract whose ABI it cannot compute");
+        Self(abi.entries().iter().map(Entry::from).collect())
+    }
+}
+
+/// An interface's own members; Slang does not expose an interface's linearisation, so members
+/// inherited from base interfaces are not listed.
+impl From<&InterfaceDefinition> for Abi {
+    fn from(interface: &InterfaceDefinition) -> Self {
+        Self::from_members(interface.members().iter())
+    }
+}
+
+impl From<&LibraryDefinition> for Abi {
+    fn from(library: &LibraryDefinition) -> Self {
+        Self::from_members(library.members().iter())
+    }
+}
+
+/// The `evm.methodIdentifiers` map: each externally dispatchable function keyed by the signature
+/// its selector hashes, each public state variable by its canonical one, selectors in lower-case
+/// hex.
+pub struct MethodIdentifiers(BTreeMap<String, String>);
+
+impl MethodIdentifiers {
+    /// Maps the given functions and state variables; a function that is not a regular external
+    /// one, or a state variable that is not public, has no identifier and is skipped.
+    pub fn new(
+        functions: impl IntoIterator<Item = FunctionDefinition>,
+        state_variables: impl IntoIterator<Item = StateVariableDefinition>,
+    ) -> Self {
+        Self(
+            functions
+                .into_iter()
+                .filter(|function| {
+                    matches!(function.kind(), FunctionKind::Regular)
+                        && function.is_externally_visible()
+                })
+                .map(|function| {
+                    (
+                        function
+                            .compute_selector_signature()
+                            .expect("an externally visible function has a selector signature"),
+                        function
+                            .compute_selector()
+                            .expect("an externally visible function has a selector"),
+                    )
+                })
+                .chain(
+                    state_variables
+                        .into_iter()
+                        .filter(StateVariableDefinition::is_externally_visible)
+                        .map(|state_variable| {
+                            (
+                                state_variable
+                                    .compute_canonical_signature()
+                                    .expect("a public state variable has a canonical signature"),
+                                state_variable
+                                    .compute_selector()
+                                    .expect("a public state variable has a selector"),
+                            )
+                        }),
+                )
+                .map(|(signature, selector)| (signature, format!("{selector:08x}")))
+                .collect(),
+        )
+    }
+
+    /// The map the standard-JSON output stores.
+    pub fn into_map(self) -> BTreeMap<String, String> {
+        self.0
+    }
+}
+
+/// The whole hierarchy, as the ABI lists it.
+impl From<&ContractDefinition> for MethodIdentifiers {
+    fn from(contract: &ContractDefinition) -> Self {
+        Self::new(
+            contract.linearised_functions(),
+            contract.linearised_state_variables(),
+        )
+    }
+}
+
+impl From<&InterfaceDefinition> for MethodIdentifiers {
+    fn from(interface: &InterfaceDefinition) -> Self {
+        Self::new(
+            interface
+                .members()
+                .iter()
+                .filter_map(|member| match member {
+                    ContractMember::FunctionDefinition(function) => Some(function),
+                    _ => None,
+                }),
+            std::iter::empty(),
+        )
     }
 }
 

--- a/solx-slang/src/abi.rs
+++ b/solx-slang/src/abi.rs
@@ -1,0 +1,228 @@
+//!
+//! The JSON ABI of a deployable object in solc's spelling. Slang computes every entry, its sort
+//! order and its getter flattening; this module only renders them.
+//!
+
+use serde::Serialize;
+use slang_solidity_v2::abi::AbiEntry;
+use slang_solidity_v2::abi::AbiMutability;
+use slang_solidity_v2::abi::AbiParameter;
+use slang_solidity_v2::abi::AbiType;
+use slang_solidity_v2::abi::ContractAbi;
+
+/// The `abi` field of a standard-JSON contract: the entries in Slang's order, which is solc's.
+///
+/// `serde_json::to_value` sorts object keys, so the rendered JSON carries solc's alphabetical
+/// key order regardless of field declaration order here.
+#[derive(Debug, Serialize)]
+pub struct Abi(Vec<Entry>);
+
+impl Abi {
+    /// The value the standard-JSON output stores.
+    pub fn into_value(self) -> serde_json::Value {
+        serde_json::to_value(self).expect("the ABI only holds strings, booleans and lists")
+    }
+}
+
+impl From<&[AbiEntry]> for Abi {
+    fn from(entries: &[AbiEntry]) -> Self {
+        Self(entries.iter().map(Entry::from).collect())
+    }
+}
+
+impl From<&ContractAbi> for Abi {
+    fn from(abi: &ContractAbi) -> Self {
+        Self::from(abi.entries())
+    }
+}
+
+/// One ABI entry, tagged by `type`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum Entry {
+    /// The constructor, nameless and without outputs.
+    Constructor {
+        /// The constructor parameters.
+        inputs: Vec<Parameter>,
+        /// `nonpayable` or `payable`.
+        #[serde(rename = "stateMutability")]
+        state_mutability: Mutability,
+    },
+    /// A custom error.
+    Error {
+        /// The error parameters.
+        inputs: Vec<Parameter>,
+        /// The error name.
+        name: String,
+    },
+    /// An event.
+    Event {
+        /// Whether the event is declared `anonymous`.
+        anonymous: bool,
+        /// The event parameters, each carrying `indexed`.
+        inputs: Vec<Parameter>,
+        /// The event name.
+        name: String,
+    },
+    /// The fallback function.
+    Fallback {
+        /// `nonpayable` or `payable`.
+        #[serde(rename = "stateMutability")]
+        state_mutability: Mutability,
+    },
+    /// An externally visible function or a public state variable's getter.
+    Function {
+        /// The function parameters.
+        inputs: Vec<Parameter>,
+        /// The function name.
+        name: String,
+        /// The return values; a struct-returning getter is flattened to its members by Slang.
+        outputs: Vec<Parameter>,
+        /// The declared mutability.
+        #[serde(rename = "stateMutability")]
+        state_mutability: Mutability,
+    },
+    /// The receive function.
+    Receive {
+        /// Always `payable`.
+        #[serde(rename = "stateMutability")]
+        state_mutability: Mutability,
+    },
+}
+
+impl From<&AbiEntry> for Entry {
+    fn from(entry: &AbiEntry) -> Self {
+        match entry {
+            AbiEntry::Constructor(constructor) => Self::Constructor {
+                inputs: Parameter::list(constructor.inputs()),
+                state_mutability: constructor.state_mutability().into(),
+            },
+            AbiEntry::Error(error) => Self::Error {
+                inputs: Parameter::list(error.inputs()),
+                name: error.name().to_owned(),
+            },
+            AbiEntry::Event(event) => Self::Event {
+                anonymous: event.anonymous(),
+                inputs: event
+                    .inputs()
+                    .iter()
+                    .map(|input| Parameter::from(input).indexed(input.indexed()))
+                    .collect(),
+                name: event.name().to_owned(),
+            },
+            AbiEntry::Fallback(fallback) => Self::Fallback {
+                state_mutability: fallback.state_mutability().into(),
+            },
+            AbiEntry::Function(function) => Self::Function {
+                inputs: Parameter::list(function.inputs()),
+                name: function.name().to_owned(),
+                outputs: Parameter::list(function.outputs()),
+                state_mutability: function.state_mutability().into(),
+            },
+            AbiEntry::Receive(receive) => Self::Receive {
+                state_mutability: receive.state_mutability().into(),
+            },
+        }
+    }
+}
+
+/// A parameter, return value or tuple component.
+#[derive(Debug, Serialize)]
+struct Parameter {
+    /// The members of a struct type, present only when `type` spells a tuple.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<Vec<Parameter>>,
+    /// Whether an event parameter is `indexed`; absent everywhere but event inputs, as in solc.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    indexed: Option<bool>,
+    /// The declared name, empty when unnamed or when Slang does not carry it (getters).
+    name: String,
+    /// The ABI type: `tuple` with array suffixes for structs, the canonical name otherwise.
+    r#type: String,
+}
+
+impl Parameter {
+    /// Renders a parameter list.
+    fn list(parameters: &[AbiParameter]) -> Vec<Self> {
+        parameters.iter().map(Self::from).collect()
+    }
+
+    /// Renders a named type; the recursion point for struct components.
+    fn new(name: String, abi_type: &AbiType) -> Self {
+        let (r#type, components) = Self::spell(abi_type);
+        Self {
+            components,
+            indexed: None,
+            name,
+            r#type,
+        }
+    }
+
+    /// Marks an event input.
+    fn indexed(mut self, indexed: bool) -> Self {
+        self.indexed = Some(indexed);
+        self
+    }
+
+    /// Spells the `type` string and the components solc attaches to it. Slang's `Display` spells
+    /// a struct in canonical-signature form `(T1,T2)`; solc's JSON spells it `tuple` and lists the
+    /// members under `components`, keeping any array suffixes on the `tuple` word.
+    fn spell(abi_type: &AbiType) -> (String, Option<Vec<Self>>) {
+        match abi_type {
+            AbiType::Array { element } => {
+                let (element, components) = Self::spell(element);
+                (format!("{element}[]"), components)
+            }
+            AbiType::FixedSizeArray { element, size } => {
+                let (element, components) = Self::spell(element);
+                (format!("{element}[{size}]"), components)
+            }
+            AbiType::Tuple(components) => (
+                "tuple".to_owned(),
+                Some(
+                    components
+                        .iter()
+                        .map(|component| {
+                            Self::new(component.name().to_owned(), component.abi_type())
+                        })
+                        .collect(),
+                ),
+            ),
+            scalar => (scalar.to_string(), None),
+        }
+    }
+}
+
+impl From<&AbiParameter> for Parameter {
+    fn from(parameter: &AbiParameter) -> Self {
+        Self::new(
+            parameter.name().unwrap_or_default().to_owned(),
+            parameter.abi_type(),
+        )
+    }
+}
+
+/// The `stateMutability` spelling.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Mutability {
+    /// Reads nothing.
+    Pure,
+    /// Reads state.
+    View,
+    /// Writes state, rejects value.
+    NonPayable,
+    /// Accepts value.
+    Payable,
+}
+
+impl From<&AbiMutability> for Mutability {
+    fn from(mutability: &AbiMutability) -> Self {
+        match mutability {
+            AbiMutability::Pure => Self::Pure,
+            AbiMutability::View => Self::View,
+            AbiMutability::NonPayable => Self::NonPayable,
+            AbiMutability::Payable => Self::Payable,
+        }
+    }
+}

--- a/solx-slang/src/contract/object.rs
+++ b/solx-slang/src/contract/object.rs
@@ -5,7 +5,9 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
+use slang_solidity_v2::abi::AbiEntry;
 use slang_solidity_v2::ast::ContractDefinition;
+use slang_solidity_v2::ast::ContractMember;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::FunctionDefinition;
 use slang_solidity_v2::ast::FunctionKind;
@@ -16,6 +18,7 @@ use slang_solidity_v2::ast::StateVariableDefinition;
 
 use solx_mlir::ContractKind;
 
+use crate::abi::Abi;
 use crate::contract::storage_slot::StorageSlot;
 
 /// The deployable object a module emits, each variant carrying the definition its kind
@@ -77,6 +80,34 @@ impl Object {
         match self {
             Self::Contract(node) => node.is_payable(),
             Self::Library(_) => false,
+        }
+    }
+
+    /// The object's JSON ABI. Slang computes a contract's whole; a library's is composed from the
+    /// entries Slang computes per member, since Slang has no library ABI.
+    pub fn abi(&self) -> Abi {
+        match self {
+            Self::Contract(node) => Abi::from(
+                &node
+                    .compute_abi()
+                    .expect("slang admits a contract whose ABI it cannot compute"),
+            ),
+            Self::Library(node) => {
+                let mut entries = node
+                    .members()
+                    .iter()
+                    .filter_map(|member| match member {
+                        ContractMember::FunctionDefinition(function) => {
+                            function.compute_abi_entry()
+                        }
+                        ContractMember::ErrorDefinition(error) => error.compute_abi_entry(),
+                        ContractMember::EventDefinition(event) => event.compute_abi_entry(),
+                        _ => None,
+                    })
+                    .collect::<Vec<AbiEntry>>();
+                entries.sort();
+                Abi::from(entries.as_slice())
+            }
         }
     }
 

--- a/solx-slang/src/contract/object.rs
+++ b/solx-slang/src/contract/object.rs
@@ -5,12 +5,9 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
-use slang_solidity_v2::abi::AbiEntry;
 use slang_solidity_v2::ast::ContractDefinition;
-use slang_solidity_v2::ast::ContractMember;
 use slang_solidity_v2::ast::Definition;
 use slang_solidity_v2::ast::FunctionDefinition;
-use slang_solidity_v2::ast::FunctionKind;
 use slang_solidity_v2::ast::Identifier;
 use slang_solidity_v2::ast::LibraryDefinition;
 use slang_solidity_v2::ast::NodeId;
@@ -19,6 +16,7 @@ use slang_solidity_v2::ast::StateVariableDefinition;
 use solx_mlir::ContractKind;
 
 use crate::abi::Abi;
+use crate::abi::MethodIdentifiers;
 use crate::contract::storage_slot::StorageSlot;
 
 /// The deployable object a module emits, each variant carrying the definition its kind
@@ -83,31 +81,11 @@ impl Object {
         }
     }
 
-    /// The object's JSON ABI. Slang computes a contract's whole; a library's is composed from the
-    /// entries Slang computes per member, since Slang has no library ABI.
+    /// The object's JSON ABI.
     pub fn abi(&self) -> Abi {
         match self {
-            Self::Contract(node) => Abi::from(
-                &node
-                    .compute_abi()
-                    .expect("slang admits a contract whose ABI it cannot compute"),
-            ),
-            Self::Library(node) => {
-                let mut entries = node
-                    .members()
-                    .iter()
-                    .filter_map(|member| match member {
-                        ContractMember::FunctionDefinition(function) => {
-                            function.compute_abi_entry()
-                        }
-                        ContractMember::ErrorDefinition(error) => error.compute_abi_entry(),
-                        ContractMember::EventDefinition(event) => event.compute_abi_entry(),
-                        _ => None,
-                    })
-                    .collect::<Vec<AbiEntry>>();
-                entries.sort();
-                Abi::from(entries.as_slice())
-            }
+            Self::Contract(node) => Abi::from(node),
+            Self::Library(node) => Abi::from(node),
         }
     }
 
@@ -153,37 +131,9 @@ impl Object {
         }
     }
 
-    /// The ABI `method_identifiers` map (externally dispatchable signature to 4-byte selector,
-    /// lower-case hex): each function keyed by the signature its selector hashes, each public
-    /// state variable by its canonical one. `convert-sol-to-yul` builds the entry-point
-    /// dispatcher from the function selectors.
+    /// The ABI `method_identifiers` map of the object's own functions and public state variables.
+    /// `convert-sol-to-yul` builds the entry-point dispatcher from the function selectors.
     pub fn method_identifiers(&self) -> BTreeMap<String, String> {
-        self.functions()
-            .iter()
-            .filter(|function| {
-                matches!(function.kind(), FunctionKind::Regular) && function.is_externally_visible()
-            })
-            .map(|function| {
-                (
-                    function
-                        .compute_selector_signature()
-                        .expect("an externally visible function has a selector signature"),
-                    function
-                        .compute_selector()
-                        .expect("an externally visible function has a selector"),
-                )
-            })
-            .chain(self.public_state_variables().iter().map(|state_variable| {
-                (
-                    state_variable
-                        .compute_canonical_signature()
-                        .expect("a public state variable has a canonical signature"),
-                    state_variable
-                        .compute_selector()
-                        .expect("a public state variable has a selector"),
-                )
-            }))
-            .map(|(signature, selector)| (signature, format!("{selector:08x}")))
-            .collect()
+        MethodIdentifiers::new(self.functions(), self.public_state_variables()).into_map()
     }
 }

--- a/solx-slang/src/lib.rs
+++ b/solx-slang/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![allow(clippy::too_many_arguments)]
 
+pub(crate) mod abi;
 pub(crate) mod contract;
 pub(crate) mod scope;
 pub(crate) mod slang;

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -57,7 +57,10 @@ impl<'context> SourceUnitScope<'context> {
                 object.identifier().as_str(),
                 capture_sol_dialect(name.as_str()),
             )?;
-            contracts.insert(name, Contract::new_mlir(mlir, method_identifiers));
+            contracts.insert(
+                name,
+                Contract::new_mlir(mlir, object.abi().into_value(), method_identifiers),
+            );
         }
         Ok(contracts)
     }

--- a/solx-slang/src/source_unit.rs
+++ b/solx-slang/src/source_unit.rs
@@ -13,16 +13,18 @@ use solx_mlir::Context;
 use solx_standard_json::output::contract::Contract;
 use solx_utils::EVMVersion;
 
+use crate::abi::Abi;
+use crate::abi::MethodIdentifiers;
 use crate::contract::object::Object;
 use crate::scope::source_unit::SourceUnitScope;
 
 impl<'context> SourceUnitScope<'context> {
     /// Lowers every contract and library the unit deploys into standard-JSON contract outputs
     /// keyed by definition name, each in its own MLIR module off the file's melior context. An
-    /// abstract contract and an interface deploy nothing and produce no module. A contract with a
-    /// contract base is skipped because emission collects only the contract's own state and
-    /// functions: an interface base carries nothing to inherit, a contract base carries state and
-    /// bodies that would be silently dropped.
+    /// abstract contract and an interface deploy nothing and produce no module, only their ABI. A
+    /// contract with a contract base is skipped because emission collects only the contract's own
+    /// state and functions: an interface base carries nothing to inherit, a contract base carries
+    /// state and bodies that would be silently dropped.
     ///
     /// # Errors
     ///
@@ -38,12 +40,31 @@ impl<'context> SourceUnitScope<'context> {
         let mut contracts = BTreeMap::new();
         for member in unit.members().iter() {
             let object = match member {
+                SourceUnitMember::ContractDefinition(contract) if contract.is_abstract() => {
+                    contracts.insert(
+                        contract.name().name().to_owned(),
+                        Contract::new_abi(
+                            Abi::from(&contract).into_value(),
+                            MethodIdentifiers::from(&contract).into_map(),
+                        ),
+                    );
+                    continue;
+                }
+                SourceUnitMember::InterfaceDefinition(interface) => {
+                    contracts.insert(
+                        interface.name().name().to_owned(),
+                        Contract::new_abi(
+                            Abi::from(&interface).into_value(),
+                            MethodIdentifiers::from(&interface).into_map(),
+                        ),
+                    );
+                    continue;
+                }
                 SourceUnitMember::ContractDefinition(contract)
-                    if !contract.is_abstract()
-                        && !contract.direct_bases().iter().any(|base| match base {
-                            ContractBase::Contract(_) => true,
-                            ContractBase::Interface(_) => false,
-                        }) =>
+                    if !contract.direct_bases().iter().any(|base| match base {
+                        ContractBase::Contract(_) => true,
+                        ContractBase::Interface(_) => false,
+                    }) =>
                 {
                     Object::Contract(contract.clone())
                 }

--- a/solx-standard-json/src/output/contract/mod.rs
+++ b/solx-standard-json/src/output/contract/mod.rs
@@ -65,6 +65,24 @@ impl Contract {
     }
 
     ///
+    /// Wraps the JSON ABI and ABI method identifiers of a definition that deploys nothing: an
+    /// interface or an abstract contract.
+    ///
+    pub fn new_abi(
+        abi: serde_json::Value,
+        method_identifiers: std::collections::BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            abi: Some(abi),
+            evm: Some(EVM {
+                method_identifiers: Some(method_identifiers),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    ///
     /// Checks if all fields are unset or empty.
     ///
     pub fn is_empty(&self) -> bool {

--- a/solx-standard-json/src/output/contract/mod.rs
+++ b/solx-standard-json/src/output/contract/mod.rs
@@ -45,14 +45,16 @@ pub struct Contract {
 
 impl Contract {
     ///
-    /// Wraps an MLIR pipeline output together with its ABI method identifiers.
+    /// Wraps an MLIR pipeline output together with its JSON ABI and ABI method identifiers.
     ///
     #[cfg(feature = "mlir")]
     pub fn new_mlir(
         mlir: solx_mlir::MlirOutput,
+        abi: serde_json::Value,
         method_identifiers: std::collections::BTreeMap<String, String>,
     ) -> Self {
         Self {
+            abi: Some(abi),
             mlir: Some(mlir),
             evm: Some(EVM {
                 method_identifiers: Some(method_identifiers),

--- a/solx/tests/cli/abi.rs
+++ b/solx/tests/cli/abi.rs
@@ -28,6 +28,10 @@ fn default() -> anyhow::Result<()> {
     crate::common::contract!("solidity/SlangTest.sol"),
     crate::common::abi!("SlangTest.json")
 )]
+#[test_case(
+    crate::common::contract!("solidity/SlangAbi.sol"),
+    crate::common::abi!("SlangAbi.json")
+)]
 fn matches_solc(contract: &str, expected: &str) -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/solx/tests/cli/abi.rs
+++ b/solx/tests/cli/abi.rs
@@ -2,7 +2,10 @@
 //! CLI tests for the eponymous option.
 //!
 
+use std::collections::BTreeMap;
+
 use predicates::prelude::*;
+use test_case::test_case;
 
 #[test]
 fn default() -> anyhow::Result<()> {
@@ -17,6 +20,61 @@ fn default() -> anyhow::Result<()> {
         .stdout(predicate::str::contains("Contract JSON ABI").count(1));
 
     Ok(())
+}
+
+/// The expected files hold solc's ABI without `internalType`, which the Slang frontend does not
+/// emit yet; both frontends are compared to them the same way.
+#[test_case(
+    crate::common::contract!("solidity/SlangTest.sol"),
+    crate::common::abi!("SlangTest.json")
+)]
+fn matches_solc(contract: &str, expected: &str) -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[contract, "--abi"];
+
+    let result = crate::cli::execute_solx(args)?;
+    let output = result.success().get_output().stdout.clone();
+    let output = String::from_utf8(output)?;
+
+    let expected: BTreeMap<String, serde_json::Value> =
+        serde_json::from_str(std::fs::read_to_string(expected)?.as_str())?;
+
+    let mut actual = BTreeMap::new();
+    let mut lines = output.lines();
+    while let Some(line) = lines.next() {
+        let Some(name) = line
+            .strip_prefix("======= ")
+            .and_then(|line| line.strip_suffix(" ======="))
+            .and_then(|full_path| full_path.rsplit(':').next())
+        else {
+            continue;
+        };
+        assert_eq!(lines.next(), Some("Contract JSON ABI:"), "{name}");
+        let abi: serde_json::Value = serde_json::from_str(lines.next().expect("ABI JSON"))?;
+        actual.insert(name.to_owned(), without_internal_type(abi));
+    }
+
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+/// Removes every `internalType` key, recursively.
+fn without_internal_type(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(without_internal_type).collect())
+        }
+        serde_json::Value::Object(members) => serde_json::Value::Object(
+            members
+                .into_iter()
+                .filter(|(key, _)| key != "internalType")
+                .map(|(key, value)| (key, without_internal_type(value)))
+                .collect(),
+        ),
+        scalar => scalar,
+    }
 }
 
 #[test]

--- a/solx/tests/cli/hashes.rs
+++ b/solx/tests/cli/hashes.rs
@@ -9,10 +9,7 @@ use tempfile::TempDir;
 fn default() -> anyhow::Result<()> {
     crate::common::setup()?;
 
-    let args = &[
-        crate::common::contract!("solidity/caller/Main.sol"),
-        "--hashes",
-    ];
+    let args = &[crate::common::TEST_SOLIDITY_CONTRACT, "--hashes"];
 
     let result = crate::cli::execute_solx(args)?;
 

--- a/solx/tests/cli/mod.rs
+++ b/solx/tests/cli/mod.rs
@@ -8,7 +8,6 @@ use std::process::Command;
 use assert_cmd::assert::Assert;
 use assert_cmd::assert::OutputAssertExt;
 
-#[cfg(feature = "solc")]
 mod abi;
 #[cfg(feature = "solc")]
 mod allow_paths;
@@ -38,7 +37,6 @@ mod ethir;
 mod evm_version;
 #[cfg(feature = "solc")]
 mod evmla;
-#[cfg(feature = "solc")]
 mod hashes;
 mod help;
 #[cfg(feature = "solc")]

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -436,6 +436,38 @@ fn abi_only_output() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// An interface and an abstract contract carry an ABI and method identifiers but no bytecode.
+#[test]
+fn abi_without_bytecode() -> anyhow::Result<()> {
+    crate::common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        crate::common::standard_json!("solidity_abi_interface.json"),
+    ];
+
+    let result = crate::cli::execute_solx(args)?;
+    let output: serde_json::Value =
+        serde_json::from_slice(result.success().get_output().stdout.as_slice())?;
+    let contracts = &output["contracts"]["A"];
+
+    for name in ["I", "B"] {
+        let contract = &contracts[name];
+        assert!(contract["abi"].is_array(), "{name} has an ABI");
+        assert!(
+            contract["evm"]["methodIdentifiers"].is_object(),
+            "{name} has method identifiers"
+        );
+        assert!(
+            contract["evm"]["bytecode"].is_null(),
+            "{name} has no bytecode"
+        );
+    }
+    assert!(contracts["C"]["evm"]["bytecode"]["object"].is_string());
+
+    Ok(())
+}
+
 #[cfg(feature = "solc")]
 #[test]
 fn devdoc_userdoc_output() -> anyhow::Result<()> {

--- a/solx/tests/cli/standard_json_output.rs
+++ b/solx/tests/cli/standard_json_output.rs
@@ -417,7 +417,6 @@ fn storage_layout_output() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "solc")]
 #[test]
 fn abi_only_output() -> anyhow::Result<()> {
     crate::common::setup()?;

--- a/solx/tests/common/mod.rs
+++ b/solx/tests/common/mod.rs
@@ -16,6 +16,14 @@ macro_rules! contract {
 }
 pub(crate) use contract;
 
+/// Returns a path under `tests/data/abi/` for expected JSON ABI files.
+macro_rules! abi {
+    ($relative:literal) => {
+        concat!("tests/data/abi/", $relative)
+    };
+}
+pub(crate) use abi;
+
 /// Returns a path under `tests/data/standard_json_input/` for standard JSON input files.
 macro_rules! standard_json {
     ($relative:literal) => {

--- a/solx/tests/data/abi/SlangAbi.json
+++ b/solx/tests/data/abi/SlangAbi.json
@@ -1,0 +1,432 @@
+{
+  "AbiBase": [
+    {
+      "inputs": [
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "abstract_function",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "AbiLibrary": [
+    {
+      "inputs": [
+        {
+          "name": "code",
+          "type": "uint256"
+        }
+      ],
+      "name": "LibraryError",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "LibraryEvent",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "external_function",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    }
+  ],
+  "IAbi": [
+    {
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ping",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "SlangAbi": [
+    {
+      "inputs": [
+        {
+          "name": "initial",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "Empty",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "name": "code",
+          "type": "uint256"
+        },
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ],
+      "name": "Failed",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "Moved",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "components": [
+            {
+              "name": "x",
+              "type": "uint256"
+            },
+            {
+              "name": "ys",
+              "type": "int128[]"
+            }
+          ],
+          "indexed": false,
+          "name": "point",
+          "type": "tuple"
+        }
+      ],
+      "name": "Traced",
+      "type": "event"
+    },
+    {
+      "stateMutability": "nonpayable",
+      "type": "fallback"
+    },
+    {
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "add",
+      "outputs": [
+        {
+          "name": "total",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "balances",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "count",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "name": "ys",
+                  "type": "int128[]"
+                }
+              ],
+              "name": "from",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "name": "ys",
+                  "type": "int128[]"
+                }
+              ],
+              "name": "to",
+              "type": "tuple"
+            },
+            {
+              "name": "choice",
+              "type": "uint8"
+            }
+          ],
+          "name": "line",
+          "type": "tuple"
+        },
+        {
+          "name": "target",
+          "type": "address"
+        },
+        {
+          "name": "callee",
+          "type": "address"
+        },
+        {
+          "name": "choice",
+          "type": "uint8"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "draw",
+      "outputs": [
+        {
+          "components": [
+            {
+              "name": "x",
+              "type": "uint256"
+            },
+            {
+              "name": "ys",
+              "type": "int128[]"
+            }
+          ],
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "hashes",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "name": "ys",
+                  "type": "int128[]"
+                }
+              ],
+              "name": "from",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "name": "ys",
+                  "type": "int128[]"
+                }
+              ],
+              "name": "to",
+              "type": "tuple"
+            },
+            {
+              "name": "choice",
+              "type": "uint8"
+            }
+          ],
+          "name": "input",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "name": "x",
+              "type": "uint256"
+            },
+            {
+              "name": "ys",
+              "type": "int128[]"
+            }
+          ],
+          "name": "pair",
+          "type": "tuple[2]"
+        }
+      ],
+      "name": "lines",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "name": "ys",
+                  "type": "int128[]"
+                }
+              ],
+              "name": "from",
+              "type": "tuple"
+            },
+            {
+              "components": [
+                {
+                  "name": "x",
+                  "type": "uint256"
+                },
+                {
+                  "name": "ys",
+                  "type": "int128[]"
+                }
+              ],
+              "name": "to",
+              "type": "tuple"
+            },
+            {
+              "name": "choice",
+              "type": "uint8"
+            }
+          ],
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "selector",
+          "type": "bytes4"
+        },
+        {
+          "name": "label",
+          "type": "string"
+        },
+        {
+          "name": "callback",
+          "type": "function"
+        }
+      ],
+      "name": "tag",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes4"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ]
+}

--- a/solx/tests/data/abi/SlangTest.json
+++ b/solx/tests/data/abi/SlangTest.json
@@ -1,0 +1,94 @@
+{
+  "SlangTest": [
+    {
+      "inputs": [
+        {
+          "name": "a",
+          "type": "uint256"
+        },
+        {
+          "name": "b",
+          "type": "uint256"
+        }
+      ],
+      "name": "add",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "a",
+          "type": "uint256"
+        },
+        {
+          "name": "b",
+          "type": "uint256"
+        }
+      ],
+      "name": "compare",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "count",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getCount",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "increment",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "n",
+          "type": "uint8"
+        }
+      ],
+      "name": "sum",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    }
+  ]
+}

--- a/solx/tests/data/contracts/solidity/SlangAbi.sol
+++ b/solx/tests/data/contracts/solidity/SlangAbi.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+type Wad is uint256;
+
+interface IAbi {
+    function ping(uint256 value) external returns (uint256);
+}
+
+library AbiLibrary {
+    error LibraryError(uint256 code);
+
+    event LibraryEvent(address account);
+
+    function external_function(uint256 value) external pure returns (uint256) {
+        return value;
+    }
+
+    function internal_function(uint256 value) internal pure returns (uint256) {
+        return value;
+    }
+}
+
+abstract contract AbiBase {
+    function abstract_function(bytes calldata data) external virtual returns (bytes memory);
+}
+
+contract SlangAbi {
+    enum Choice {
+        Left,
+        Right
+    }
+
+    struct Point {
+        uint256 x;
+        int128[] ys;
+    }
+
+    struct Line {
+        Point from;
+        Point to;
+        Choice choice;
+    }
+
+    error Failed(uint256 code, string reason);
+    error Empty();
+
+    event Moved(address indexed from, address indexed to, uint256 amount);
+    event Traced(Point point) anonymous;
+
+    uint256 public count;
+    mapping(address => uint256) public balances;
+    bytes32[] public hashes;
+
+    constructor(uint256 initial) payable {
+        count = initial;
+    }
+
+    receive() external payable {}
+
+    fallback() external {}
+
+    function add(uint256 value) external returns (uint256 total) {
+        count += value;
+        return count;
+    }
+
+    function draw(Line calldata line, address payable target, IAbi callee, Choice choice, Wad wad)
+        external
+        pure
+        returns (Point memory, bool)
+    {
+        return (line.from, target != address(0) && address(callee) != address(0) && choice == Choice.Left && Wad.unwrap(wad) == 0);
+    }
+
+    function lines(Line[] memory input, Point[2] memory pair) external pure returns (Line[] memory) {
+        return input;
+    }
+
+    function tag(bytes4 selector, string memory label, function(uint256) external callback) external pure returns (bytes4) {
+        return selector;
+    }
+}

--- a/solx/tests/data/standard_json_input/solidity_abi_interface.json
+++ b/solx/tests/data/standard_json_input/solidity_abi_interface.json
@@ -1,0 +1,19 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: Unlicensed\npragma solidity >=0.8.0; interface I { function ping(uint256 value) external returns (uint256); } abstract contract B { function pong() external virtual; } contract C is I { function ping(uint256 value) external pure returns (uint256) { return value; } }"
+    }
+  },
+  "settings": {
+    "outputSelection": {
+      "*": {
+        "*": [
+          "abi",
+          "evm.bytecode.object",
+          "evm.methodIdentifiers"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
TODO: this PR is in a temporary state as most of this implementation will move to slang repo.


# Claude summary
Emits the JSON ABI in solc's spelling for every contract, interface, abstract contract and library the Slang frontend compiles, and lets `--abi` and `--hashes` through the CLI selection under it. The `abi::matches_solc` test pins parity with solc's ABI, `internalType` excluded until Slang carries it.
