### PR TITLE
feat(slang): take the JSON ABI from Slang's serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4862,7 +4862,6 @@ dependencies = [
  "num-traits",
  "ruint",
  "semver 1.0.28",
- "serde",
  "serde_json",
  "slang_solidity_v2",
  "solx-core",

--- a/solx-slang/Cargo.toml
+++ b/solx-slang/Cargo.toml
@@ -14,7 +14,6 @@ anyhow.workspace = true
 num.workspace = true
 num-traits = "0.2"
 ruint.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 semver.workspace = true
 

--- a/solx-slang/src/abi.rs
+++ b/solx-slang/src/abi.rs
@@ -1,15 +1,11 @@
 //!
-//! The JSON ABI of a contract, interface or library in solc's spelling. Slang computes every
-//! entry, its order and its getter flattening; this module only renders them.
+//! The ABI outputs of a definition in standard-JSON form: the JSON ABI Slang computes and
+//! serializes in solc's spelling, and the `evm.methodIdentifiers` map.
 //!
 
 use std::collections::BTreeMap;
 
-use serde::Serialize;
-use slang_solidity_v2::abi::AbiEntry;
-use slang_solidity_v2::abi::AbiMutability;
-use slang_solidity_v2::abi::AbiParameter;
-use slang_solidity_v2::abi::AbiType;
+use slang_solidity_v2::abi::ContractAbi;
 use slang_solidity_v2::ast::ContractDefinition;
 use slang_solidity_v2::ast::ContractMember;
 use slang_solidity_v2::ast::FunctionDefinition;
@@ -18,55 +14,43 @@ use slang_solidity_v2::ast::InterfaceDefinition;
 use slang_solidity_v2::ast::LibraryDefinition;
 use slang_solidity_v2::ast::StateVariableDefinition;
 
-/// The `abi` field of a standard-JSON contract: the entries in Slang's order, which is solc's.
-///
-/// `serde_json::to_value` sorts object keys, so the rendered JSON carries solc's alphabetical
-/// key order regardless of field declaration order here.
-#[derive(Debug, Serialize)]
-pub struct Abi(Vec<Entry>);
+/// The `abi` field of a standard-JSON contract.
+pub struct Abi(ContractAbi);
 
 impl Abi {
-    /// The value the standard-JSON output stores.
+    /// The value the standard-JSON output stores: Slang's entries in solc's JSON-ABI spelling.
     pub fn into_value(self) -> serde_json::Value {
-        serde_json::to_value(self).expect("the ABI only holds strings, booleans and lists")
-    }
-
-    /// Composes the ABI of a definition Slang has no whole ABI for from the entries it computes
-    /// per member, in Slang's order.
-    fn from_members(members: impl Iterator<Item = ContractMember>) -> Self {
-        let mut entries = members
-            .filter_map(|member| match member {
-                ContractMember::FunctionDefinition(function) => function.compute_abi_entry(),
-                ContractMember::ErrorDefinition(error) => error.compute_abi_entry(),
-                ContractMember::EventDefinition(event) => event.compute_abi_entry(),
-                _ => None,
-            })
-            .collect::<Vec<AbiEntry>>();
-        entries.sort();
-        Self(entries.iter().map(Entry::from).collect())
+        serde_json::to_value(self.0.entries()).expect("the ABI only holds strings and booleans")
     }
 }
 
 impl From<&ContractDefinition> for Abi {
     fn from(contract: &ContractDefinition) -> Self {
-        let abi = contract
-            .compute_abi()
-            .expect("slang admits a contract whose ABI it cannot compute");
-        Self(abi.entries().iter().map(Entry::from).collect())
+        Self(
+            contract
+                .compute_abi()
+                .expect("slang admits a contract whose ABI it cannot compute"),
+        )
     }
 }
 
-/// An interface's own members; Slang does not expose an interface's linearisation, so members
-/// inherited from base interfaces are not listed.
 impl From<&InterfaceDefinition> for Abi {
     fn from(interface: &InterfaceDefinition) -> Self {
-        Self::from_members(interface.members().iter())
+        Self(
+            interface
+                .compute_abi()
+                .expect("slang admits an interface whose ABI it cannot compute"),
+        )
     }
 }
 
 impl From<&LibraryDefinition> for Abi {
     fn from(library: &LibraryDefinition) -> Self {
-        Self::from_members(library.members().iter())
+        Self(
+            library
+                .compute_abi()
+                .expect("slang admits a library whose ABI it cannot compute"),
+        )
     }
 }
 
@@ -147,196 +131,5 @@ impl From<&InterfaceDefinition> for MethodIdentifiers {
                 }),
             std::iter::empty(),
         )
-    }
-}
-
-/// One ABI entry, tagged by `type`.
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-enum Entry {
-    /// The constructor, nameless and without outputs.
-    Constructor {
-        /// The constructor parameters.
-        inputs: Vec<Parameter>,
-        /// `nonpayable` or `payable`.
-        #[serde(rename = "stateMutability")]
-        state_mutability: Mutability,
-    },
-    /// A custom error.
-    Error {
-        /// The error parameters.
-        inputs: Vec<Parameter>,
-        /// The error name.
-        name: String,
-    },
-    /// An event.
-    Event {
-        /// Whether the event is declared `anonymous`.
-        anonymous: bool,
-        /// The event parameters, each carrying `indexed`.
-        inputs: Vec<Parameter>,
-        /// The event name.
-        name: String,
-    },
-    /// The fallback function.
-    Fallback {
-        /// `nonpayable` or `payable`.
-        #[serde(rename = "stateMutability")]
-        state_mutability: Mutability,
-    },
-    /// An externally visible function or a public state variable's getter.
-    Function {
-        /// The function parameters.
-        inputs: Vec<Parameter>,
-        /// The function name.
-        name: String,
-        /// The return values; a struct-returning getter is flattened to its members by Slang.
-        outputs: Vec<Parameter>,
-        /// The declared mutability.
-        #[serde(rename = "stateMutability")]
-        state_mutability: Mutability,
-    },
-    /// The receive function.
-    Receive {
-        /// Always `payable`.
-        #[serde(rename = "stateMutability")]
-        state_mutability: Mutability,
-    },
-}
-
-impl From<&AbiEntry> for Entry {
-    fn from(entry: &AbiEntry) -> Self {
-        match entry {
-            AbiEntry::Constructor(constructor) => Self::Constructor {
-                inputs: Parameter::list(constructor.inputs()),
-                state_mutability: constructor.state_mutability().into(),
-            },
-            AbiEntry::Error(error) => Self::Error {
-                inputs: Parameter::list(error.inputs()),
-                name: error.name().to_owned(),
-            },
-            AbiEntry::Event(event) => Self::Event {
-                anonymous: event.anonymous(),
-                inputs: event
-                    .inputs()
-                    .iter()
-                    .map(|input| Parameter::from(input).indexed(input.indexed()))
-                    .collect(),
-                name: event.name().to_owned(),
-            },
-            AbiEntry::Fallback(fallback) => Self::Fallback {
-                state_mutability: fallback.state_mutability().into(),
-            },
-            AbiEntry::Function(function) => Self::Function {
-                inputs: Parameter::list(function.inputs()),
-                name: function.name().to_owned(),
-                outputs: Parameter::list(function.outputs()),
-                state_mutability: function.state_mutability().into(),
-            },
-            AbiEntry::Receive(receive) => Self::Receive {
-                state_mutability: receive.state_mutability().into(),
-            },
-        }
-    }
-}
-
-/// A parameter, return value or tuple component.
-#[derive(Debug, Serialize)]
-struct Parameter {
-    /// The members of a struct type, present only when `type` spells a tuple.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<Vec<Parameter>>,
-    /// Whether an event parameter is `indexed`; absent everywhere but event inputs, as in solc.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    indexed: Option<bool>,
-    /// The declared name, empty when unnamed or when Slang does not carry it (getters).
-    name: String,
-    /// The ABI type: `tuple` with array suffixes for structs, the canonical name otherwise.
-    r#type: String,
-}
-
-impl Parameter {
-    /// Renders a parameter list.
-    fn list(parameters: &[AbiParameter]) -> Vec<Self> {
-        parameters.iter().map(Self::from).collect()
-    }
-
-    /// Renders a named type; the recursion point for struct components.
-    fn new(name: String, abi_type: &AbiType) -> Self {
-        let (r#type, components) = Self::spell(abi_type);
-        Self {
-            components,
-            indexed: None,
-            name,
-            r#type,
-        }
-    }
-
-    /// Marks an event input.
-    fn indexed(mut self, indexed: bool) -> Self {
-        self.indexed = Some(indexed);
-        self
-    }
-
-    /// Spells the `type` string and the components solc attaches to it. Slang's `Display` spells
-    /// a struct in canonical-signature form `(T1,T2)`; solc's JSON spells it `tuple` and lists the
-    /// members under `components`, keeping any array suffixes on the `tuple` word.
-    fn spell(abi_type: &AbiType) -> (String, Option<Vec<Self>>) {
-        match abi_type {
-            AbiType::Array { element } => {
-                let (element, components) = Self::spell(element);
-                (format!("{element}[]"), components)
-            }
-            AbiType::FixedSizeArray { element, size } => {
-                let (element, components) = Self::spell(element);
-                (format!("{element}[{size}]"), components)
-            }
-            AbiType::Tuple(components) => (
-                "tuple".to_owned(),
-                Some(
-                    components
-                        .iter()
-                        .map(|component| {
-                            Self::new(component.name().to_owned(), component.abi_type())
-                        })
-                        .collect(),
-                ),
-            ),
-            scalar => (scalar.to_string(), None),
-        }
-    }
-}
-
-impl From<&AbiParameter> for Parameter {
-    fn from(parameter: &AbiParameter) -> Self {
-        Self::new(
-            parameter.name().unwrap_or_default().to_owned(),
-            parameter.abi_type(),
-        )
-    }
-}
-
-/// The `stateMutability` spelling.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum Mutability {
-    /// Reads nothing.
-    Pure,
-    /// Reads state.
-    View,
-    /// Writes state, rejects value.
-    NonPayable,
-    /// Accepts value.
-    Payable,
-}
-
-impl From<&AbiMutability> for Mutability {
-    fn from(mutability: &AbiMutability) -> Self {
-        match mutability {
-            AbiMutability::Pure => Self::Pure,
-            AbiMutability::View => Self::View,
-            AbiMutability::NonPayable => Self::NonPayable,
-            AbiMutability::Payable => Self::Payable,
-        }
     }
 }

--- a/solx/tests/cli/abi.rs
+++ b/solx/tests/cli/abi.rs
@@ -22,8 +22,7 @@ fn default() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The expected files hold solc's ABI without `internalType`, which the Slang frontend does not
-/// emit yet; both frontends are compared to them the same way.
+/// The expected files hold solc's ABI verbatim; both frontends are compared to them the same way.
 #[test_case(
     crate::common::contract!("solidity/SlangTest.sol"),
     crate::common::abi!("SlangTest.json")
@@ -56,29 +55,12 @@ fn matches_solc(contract: &str, expected: &str) -> anyhow::Result<()> {
         };
         assert_eq!(lines.next(), Some("Contract JSON ABI:"), "{name}");
         let abi: serde_json::Value = serde_json::from_str(lines.next().expect("ABI JSON"))?;
-        actual.insert(name.to_owned(), without_internal_type(abi));
+        actual.insert(name.to_owned(), abi);
     }
 
     assert_eq!(actual, expected);
 
     Ok(())
-}
-
-/// Removes every `internalType` key, recursively.
-fn without_internal_type(value: serde_json::Value) -> serde_json::Value {
-    match value {
-        serde_json::Value::Array(values) => {
-            serde_json::Value::Array(values.into_iter().map(without_internal_type).collect())
-        }
-        serde_json::Value::Object(members) => serde_json::Value::Object(
-            members
-                .into_iter()
-                .filter(|(key, _)| key != "internalType")
-                .map(|(key, value)| (key, without_internal_type(value)))
-                .collect(),
-        ),
-        scalar => scalar,
-    }
 }
 
 #[test]

--- a/solx/tests/data/abi/SlangAbi.json
+++ b/solx/tests/data/abi/SlangAbi.json
@@ -3,6 +3,7 @@
     {
       "inputs": [
         {
+          "internalType": "bytes",
           "name": "data",
           "type": "bytes"
         }
@@ -10,6 +11,7 @@
       "name": "abstract_function",
       "outputs": [
         {
+          "internalType": "bytes",
           "name": "",
           "type": "bytes"
         }
@@ -22,6 +24,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "code",
           "type": "uint256"
         }
@@ -34,6 +37,7 @@
       "inputs": [
         {
           "indexed": false,
+          "internalType": "address",
           "name": "account",
           "type": "address"
         }
@@ -44,6 +48,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "value",
           "type": "uint256"
         }
@@ -51,6 +56,7 @@
       "name": "external_function",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -63,6 +69,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "value",
           "type": "uint256"
         }
@@ -70,6 +77,7 @@
       "name": "ping",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -82,6 +90,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "initial",
           "type": "uint256"
         }
@@ -97,10 +106,12 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "code",
           "type": "uint256"
         },
         {
+          "internalType": "string",
           "name": "reason",
           "type": "string"
         }
@@ -113,16 +124,19 @@
       "inputs": [
         {
           "indexed": true,
+          "internalType": "address",
           "name": "from",
           "type": "address"
         },
         {
           "indexed": true,
+          "internalType": "address",
           "name": "to",
           "type": "address"
         },
         {
           "indexed": false,
+          "internalType": "uint256",
           "name": "amount",
           "type": "uint256"
         }
@@ -136,15 +150,18 @@
         {
           "components": [
             {
+              "internalType": "uint256",
               "name": "x",
               "type": "uint256"
             },
             {
+              "internalType": "int128[]",
               "name": "ys",
               "type": "int128[]"
             }
           ],
           "indexed": false,
+          "internalType": "struct SlangAbi.Point",
           "name": "point",
           "type": "tuple"
         }
@@ -159,6 +176,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "value",
           "type": "uint256"
         }
@@ -166,6 +184,7 @@
       "name": "add",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "total",
           "type": "uint256"
         }
@@ -176,6 +195,7 @@
     {
       "inputs": [
         {
+          "internalType": "address",
           "name": "",
           "type": "address"
         }
@@ -183,6 +203,7 @@
       "name": "balances",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -195,6 +216,7 @@
       "name": "count",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -209,52 +231,64 @@
             {
               "components": [
                 {
+                  "internalType": "uint256",
                   "name": "x",
                   "type": "uint256"
                 },
                 {
+                  "internalType": "int128[]",
                   "name": "ys",
                   "type": "int128[]"
                 }
               ],
+              "internalType": "struct SlangAbi.Point",
               "name": "from",
               "type": "tuple"
             },
             {
               "components": [
                 {
+                  "internalType": "uint256",
                   "name": "x",
                   "type": "uint256"
                 },
                 {
+                  "internalType": "int128[]",
                   "name": "ys",
                   "type": "int128[]"
                 }
               ],
+              "internalType": "struct SlangAbi.Point",
               "name": "to",
               "type": "tuple"
             },
             {
+              "internalType": "enum SlangAbi.Choice",
               "name": "choice",
               "type": "uint8"
             }
           ],
+          "internalType": "struct SlangAbi.Line",
           "name": "line",
           "type": "tuple"
         },
         {
+          "internalType": "address payable",
           "name": "target",
           "type": "address"
         },
         {
+          "internalType": "contract IAbi",
           "name": "callee",
           "type": "address"
         },
         {
+          "internalType": "enum SlangAbi.Choice",
           "name": "choice",
           "type": "uint8"
         },
         {
+          "internalType": "Wad",
           "name": "wad",
           "type": "uint256"
         }
@@ -264,18 +298,22 @@
         {
           "components": [
             {
+              "internalType": "uint256",
               "name": "x",
               "type": "uint256"
             },
             {
+              "internalType": "int128[]",
               "name": "ys",
               "type": "int128[]"
             }
           ],
+          "internalType": "struct SlangAbi.Point",
           "name": "",
           "type": "tuple"
         },
         {
+          "internalType": "bool",
           "name": "",
           "type": "bool"
         }
@@ -286,6 +324,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -293,6 +332,7 @@
       "name": "hashes",
       "outputs": [
         {
+          "internalType": "bytes32",
           "name": "",
           "type": "bytes32"
         }
@@ -307,50 +347,61 @@
             {
               "components": [
                 {
+                  "internalType": "uint256",
                   "name": "x",
                   "type": "uint256"
                 },
                 {
+                  "internalType": "int128[]",
                   "name": "ys",
                   "type": "int128[]"
                 }
               ],
+              "internalType": "struct SlangAbi.Point",
               "name": "from",
               "type": "tuple"
             },
             {
               "components": [
                 {
+                  "internalType": "uint256",
                   "name": "x",
                   "type": "uint256"
                 },
                 {
+                  "internalType": "int128[]",
                   "name": "ys",
                   "type": "int128[]"
                 }
               ],
+              "internalType": "struct SlangAbi.Point",
               "name": "to",
               "type": "tuple"
             },
             {
+              "internalType": "enum SlangAbi.Choice",
               "name": "choice",
               "type": "uint8"
             }
           ],
+          "internalType": "struct SlangAbi.Line[]",
           "name": "input",
           "type": "tuple[]"
         },
         {
           "components": [
             {
+              "internalType": "uint256",
               "name": "x",
               "type": "uint256"
             },
             {
+              "internalType": "int128[]",
               "name": "ys",
               "type": "int128[]"
             }
           ],
+          "internalType": "struct SlangAbi.Point[2]",
           "name": "pair",
           "type": "tuple[2]"
         }
@@ -362,36 +413,44 @@
             {
               "components": [
                 {
+                  "internalType": "uint256",
                   "name": "x",
                   "type": "uint256"
                 },
                 {
+                  "internalType": "int128[]",
                   "name": "ys",
                   "type": "int128[]"
                 }
               ],
+              "internalType": "struct SlangAbi.Point",
               "name": "from",
               "type": "tuple"
             },
             {
               "components": [
                 {
+                  "internalType": "uint256",
                   "name": "x",
                   "type": "uint256"
                 },
                 {
+                  "internalType": "int128[]",
                   "name": "ys",
                   "type": "int128[]"
                 }
               ],
+              "internalType": "struct SlangAbi.Point",
               "name": "to",
               "type": "tuple"
             },
             {
+              "internalType": "enum SlangAbi.Choice",
               "name": "choice",
               "type": "uint8"
             }
           ],
+          "internalType": "struct SlangAbi.Line[]",
           "name": "",
           "type": "tuple[]"
         }
@@ -402,14 +461,17 @@
     {
       "inputs": [
         {
+          "internalType": "bytes4",
           "name": "selector",
           "type": "bytes4"
         },
         {
+          "internalType": "string",
           "name": "label",
           "type": "string"
         },
         {
+          "internalType": "function (uint256) external",
           "name": "callback",
           "type": "function"
         }
@@ -417,6 +479,7 @@
       "name": "tag",
       "outputs": [
         {
+          "internalType": "bytes4",
           "name": "",
           "type": "bytes4"
         }

--- a/solx/tests/data/abi/SlangTest.json
+++ b/solx/tests/data/abi/SlangTest.json
@@ -3,10 +3,12 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "a",
           "type": "uint256"
         },
         {
+          "internalType": "uint256",
           "name": "b",
           "type": "uint256"
         }
@@ -14,6 +16,7 @@
       "name": "add",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -24,10 +27,12 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
           "name": "a",
           "type": "uint256"
         },
         {
+          "internalType": "uint256",
           "name": "b",
           "type": "uint256"
         }
@@ -35,6 +40,7 @@
       "name": "compare",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -47,6 +53,7 @@
       "name": "count",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -59,6 +66,7 @@
       "name": "getCount",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }
@@ -76,6 +84,7 @@
     {
       "inputs": [
         {
+          "internalType": "uint8",
           "name": "n",
           "type": "uint8"
         }
@@ -83,6 +92,7 @@
       "name": "sum",
       "outputs": [
         {
+          "internalType": "uint256",
           "name": "",
           "type": "uint256"
         }


### PR DESCRIPTION
Slang now serializes its ABI in solc's JSON form, `internalType` and getter output names included, and computes an interface's and a library's ABI itself, so the frontend passes `serde_json::to_value(abi.entries())` through and the renderer from #702 goes; the expected ABIs become solc's verbatim. Stacked on #702 and waiting on the slang change (branch `abi-json-serialize`) and its pin bump: against the current pin this does not build.
